### PR TITLE
Fix for links to and input reference for places

### DIFF
--- a/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
+++ b/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
@@ -357,7 +357,6 @@ paths:
               enum:
                 - ALL
                 - TRIPS
-                - TRIPS.PLACES
                 - NONE
             default: [ALL]
             maxItems: 2
@@ -473,7 +472,6 @@ paths:
                 - ALL
                 - TRIPOFFERS
                 - TRIPOFFERS.TRIPS
-                - TRIPOFFERS.TRIPS.PLACES
                 - TRIPOFFERS.OFFERS
                 - TRIPOFFERS.OFFERS.OFFERPARTS
                 - TRIPOFFERS.PASSENGERS
@@ -536,7 +534,6 @@ paths:
               enum:
                 - ALL
                 - TRIPS
-                - TRIPS.PLACES
                 - OFFERS
                 - OFFERS.OFFERPARTS
                 - PASSENGERS
@@ -715,7 +712,6 @@ paths:
                 - ALL
                 - OFFERPARTS
                 - TRIP
-                - TRIP.PLACES
                 - NONE
             default: [ALL]
             maxItems: 3
@@ -1587,7 +1583,6 @@ paths:
               enum:
                 - ALL
                 - BOOKEDOFFERS.TRIP
-                - BOOKEDOFFERS.TRIP.PLACES
                 - BOOKEDOFFERS
                 - BOOKEDOFFERS.OFFERPARTS
                 - PASSENGERS
@@ -2156,7 +2151,6 @@ paths:
               enum:
                 - ALL
                 - TRIP
-                - TRIP.PLACES
                 - OFFERS
                 - OFFERS.OFFERPARTS
                 - OFFERS.OFFERPARTS.PRODUCTS
@@ -2376,7 +2370,6 @@ paths:
                 - ALL
                 - TRIPOFFERS
                 - TRIPOFFERS.TRIPS
-                - TRIPOFFERS.TRIPS.PLACES
                 - TRIPOFFERS.OFFERS
                 - TRIPOFFERS.OFFERS.OFFERPARTS
                 - TRIPOFFERS.OFFERS.OFFERPARTS.PRODUCTS
@@ -2441,7 +2434,6 @@ paths:
               enum:
                 - ALL
                 - TRIPS
-                - TRIPS.PLACES
                 - OFFERS
                 - OFFERS.OFFERPARTS
                 - OFFERS.OFFERPARTS.PRODUCTS
@@ -3052,11 +3044,11 @@ components:
         origin: # EXT Array out of Scope
           description: >-
             Specifies the origin situation from where the user wants to start.
-          $ref: "#/components/schemas/PlaceRef"
+          $ref: "#/components/schemas/PlaceInput"
         destination: # EXT Array out of Scope
           description: >-
             Specifies the destination situation where the user is heading to.
-          $ref: "#/components/schemas/PlaceRef"
+          $ref: "#/components/schemas/PlaceInput"
         requestedSection: # EXT Indicates sub part of trip that is requested to price.
           $ref: "#/components/schemas/Section"
         via:
@@ -3094,7 +3086,6 @@ components:
             type: string
             enum:
               - TRIPS
-              - TRIPS.PLACES
               - NONE
               - ALL
           default: [ALL]
@@ -3514,7 +3505,7 @@ components:
         timedLeg:
           $ref: "#/components/schemas/TimedLegSpecification"
         transferLeg:
-          $ref: "#/components/schemas/TransferLeg"
+          $ref: "#/components/schemas/TransferLegSpecification"
         # continuousLeg:
         #   $ref: "#/components/schemas/ContinuousLeg"
 
@@ -3574,6 +3565,26 @@ components:
             $ref: "#/components/schemas/LegIntermediateSpecification"
         end:
           $ref: "#/components/schemas/LegAlightSpecification"
+        service:
+          $ref: "#/components/schemas/DatedJourney"
+
+    TransferLegSpecification:
+      type: object
+      description: >-
+        A minimal timed leg specification.
+      required:
+        - start # EXT legBoard renamed to start
+        - end # EXT legAlight renamed to board
+        - service
+      properties:
+        start:
+          $ref: "#/components/schemas/PlaceInput"
+        intermediates:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlaceInput"
+        end:
+          $ref: "#/components/schemas/PlaceInput"
         service:
           $ref: "#/components/schemas/DatedJourney"
 
@@ -3839,14 +3850,11 @@ components:
       type: object
       description: Minimal leg board specification.
       required:
-        - stopPlaceRef ## EXT stopPlaceRef instead of stopPointRef
+        - placeInput ## EXT stopPlaceRef instead of stopPointRef
         - serviceDeparture
       properties:
-        stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
-        stopPlaceName:
-          type: string
-          example: Luzern
+        placeInput:
+          $ref: "#/components/schemas/PlaceInput" ## EXT stopPlaceRef instead of stopPointRef
         serviceDeparture:
           description: >-
             Describes the departure situation at this leg board stop point (group of attributes
@@ -3902,11 +3910,8 @@ components:
         - serviceArrival
         - serviceDeparture
       properties:
-        stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
-        stopPlaceName:
-          type: string
-          example: Luzern
+        placeInput:
+          $ref: "#/components/schemas/PlaceInput" ## EXT stopPlaceRef instead of stopPointRef
         serviceArrival:
           description: >-
             Describes the arrival situation at this leg board stop point (group of attributes
@@ -3957,14 +3962,11 @@ components:
       type: object
       description: Minimal leg alight specification
       required:
-        - stopPlaceRef ## EXT stopPlaceRef instead of stopPointRef
+        - placeInput ## EXT stopPlaceRef instead of stopPointRef
         - serviceArrival
       properties:
-        stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
-        stopPlaceName:
-          type: string
-          example: Luzern
+        stopPlaceInput:
+          $ref: "#/components/schemas/GenericPlaceInput" ## EXT stopPlaceRef instead of stopPointRef
         serviceArrival:
           description: >-
             Describes the arrival situation at this leg board stop point (group of attributes
@@ -4343,6 +4345,59 @@ components:
         #   $ref: "#/components/schemas/TopographicPlaceRef"
         # - $ref: "#/components/schemas/StopAttributes" # Out of scope
 
+    PlaceInput:
+      type: object
+      description: structure used to specify places in requests
+      oneOf:
+        - $ref: "#/components/schemas/GenericPlaceInput"
+        - $ref: "#/components/schemas/FareConnectionPointInput"
+        - $ref: "#/components/schemas/GeoPositionInput"
+      discriminator:
+        propertyName: placeInputType
+
+    GenericPlaceInput:
+      type: object
+      description: referencing an OSDM place by its URN
+      properties:
+        placeInputType:
+            type: string
+            enum:
+            - genericPlaceInput
+        placeInput:
+          type: string
+          example: "urn:uic:stn:8500000"
+    
+    FareConnectionPointInput:
+      type: object
+      description: referencing an OSDM fareconnection point by actyally repeating its entire structure 
+      properties:
+        placeInputType:
+          type: string
+          enum:
+            - fareConnectionPointInput
+        stationSets:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              example: "urn:uic:stn:8500000"
+
+    GeoPositionInput:
+      type: object
+      description: for providing geocoordinates as input criteria 
+      properties:
+        placeInputType:
+          type: string
+          enum:
+            - geoPositionInput
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+
+        
+    
     PlaceRef: ### OJP
       oneOf:
         - $ref: "#/components/schemas/StopPlaceRef"
@@ -4366,10 +4421,7 @@ components:
           enum:
             - stopPlaceRef
         stopPlaceRef:
-          type: string
-          example: urn:uic:stn:8503000
-        name:
-          type: string
+          $ref: "#/components/schemas/Link"
 
     PointOfInterestRef: ## OJP
       type: object
@@ -4383,9 +4435,7 @@ components:
           enum:
             - pointOfInterestRef
         pointOfInterestRef:
-          type: string
-        name:
-          type: string
+          $ref: "#/components/schemas/Link"
 
     AddressRef: ## OJP
       type: object
@@ -4399,9 +4449,7 @@ components:
           enum:
             - addressRef
         addressRef:
-          type: string
-        name:
-          type: string
+          $ref: "#/components/schemas/Link"
 
     FareConnectionPointRef:
       type: object
@@ -4414,10 +4462,8 @@ components:
           type: string
           enum:
             - fareConnectionPointRef
-        fareConnectionPoint:
-          $ref: "#/components/schemas/FareConnectionPoint"
-        name:
-          type: string
+        fareConnectionPointRef:
+          $ref: "#/components/schemas/Link"
 
     ProductCategoryRef: ## OJP
       description: >-
@@ -4586,7 +4632,6 @@ components:
               - ALL
               - TRIPOFFERS
               - TRIPOFFERS.TRIP
-              - TRIPOFFERS.TRIP.PLACES
               - TRIPOFFERS.OFFERS
               - TRIPOFFERS.OFFERS.OFFERPARTS
               - TRIPOFFERS.PASSENGERS
@@ -5394,7 +5439,6 @@ components:
               - ALL
               - BOOKEDOFFERS
               - BOOKEDOFFERS.TRIPS
-              - BOOKEDOFFERS.TRIPS.PLACES
               - BOOKEDOFFERS.OFFERPARTS
               - PASSENGERS
               - REFUND_PROPOSITIONS
@@ -6122,7 +6166,6 @@ components:
             enum:
               - ALL
               - TRIP
-              - TRIP.PLACES
               - OFFERS
               - OFFERS.OFFERPARTS
               - OFFERS.OFFERPARTS.PRODUCTS
@@ -6157,9 +6200,9 @@ components:
           items:
             type: string
         origin:
-          $ref: "#/components/schemas/PlaceRef"
+          $ref: "#/components/schemas/PlaceInput"
         destination:
-          $ref: "#/components/schemas/PlaceRef"
+          $ref: "#/components/schemas/PlaceInput"
         travelPeriods:
           type: array
           items:

--- a/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
+++ b/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
@@ -3819,14 +3819,10 @@ components:
       #allOf:
       required:
         - stopPlaceRef ## EXT stopPlaceRef instead of stopPointRef
-        - stopPlaceName ## EXT stopPlaceName instead of stopPointRef
         - serviceDeparture
       properties:
         stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
-        stopPlaceName:
-          type: string
-          example: Luzern
+          $ref: "#/components/schemas/PlaceRef" ## EXT stopPlaceRef instead of stopPointRef
         plannedStopPointName:
           description: >-
             Name of the bay/quay/terminal where to board/alight from the vehicle. According to 
@@ -3868,16 +3864,12 @@ components:
         LegAlight stop or station including time-related information. Provided by OJP.
       #allOf:
       required:
-        - stopPlaceRef ## EXT stopPlaceRef instead of stopPointRef
-        - stopPlaceName ## EXT stopPlaceName instead of stopPointName
+        - PlaceRef ## EXT stopPlaceRef instead of stopPointRef
         - serviceArrival
         - serviceDeparture
       properties:
         stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
-        stopPlaceName: ## EXT stopPlaceName instead of stopPointName
-          type: string
-          example: Luzern
+          $ref: "#/components/schemas/PlaceRef" ## EXT stopPlaceRef instead of stopPointRef
         plannedStopPointName:
           description: >-
             Name of the bay/quay/terminal where to board/alight from the vehicle. According to 
@@ -3935,7 +3927,7 @@ components:
         - serviceArrival
       properties:
         stopPlaceRef:
-          $ref: "#/components/schemas/StopPlaceRef" ## EXT stopPlaceRef instead of stopPointRef
+          $ref: "#/components/schemas/PlaceRef" ## EXT stopPlaceRef instead of stopPointRef
         stopPlaceName:
           type: string
           example: Luzern
@@ -3966,7 +3958,7 @@ components:
         - serviceArrival
       properties:
         stopPlaceInput:
-          $ref: "#/components/schemas/GenericPlaceInput" ## EXT stopPlaceRef instead of stopPointRef
+          $ref: "#/components/schemas/PlaceInput" ## EXT stopPlaceRef instead of stopPointRef
         serviceArrival:
           description: >-
             Describes the arrival situation at this leg board stop point (group of attributes
@@ -4328,7 +4320,7 @@ components:
       properties:
         ref:
           description: Reference to a Stop Place
-          $ref: "#/components/schemas/StopPlaceRef"
+          $ref: "#/components/schemas/PlaceRef"
         name:
           description: Name of this stop place for use in passenger information.
           type: string
@@ -4348,123 +4340,21 @@ components:
     PlaceInput:
       type: object
       description: structure used to specify places in requests
-      oneOf:
-        - $ref: "#/components/schemas/GenericPlaceInput"
-        - $ref: "#/components/schemas/FareConnectionPointInput"
-        - $ref: "#/components/schemas/GeoPositionInput"
-      discriminator:
-        propertyName: placeInputType
-
-    GenericPlaceInput:
-      type: object
-      description: referencing an OSDM place by its URN
       properties:
-        placeInputType:
-            type: string
-            enum:
-            - genericPlaceInput
         placeInput:
           type: string
           example: "urn:uic:stn:8500000"
-    
-    FareConnectionPointInput:
-      type: object
-      description: referencing an OSDM fareconnection point by actyally repeating its entire structure 
-      properties:
-        placeInputType:
-          type: string
-          enum:
-            - fareConnectionPointInput
-        stationSets:
-          type: array
-          items:
-            type: array
-            items:
-              type: string
-              example: "urn:uic:stn:8500000"
-
-    GeoPositionInput:
-      type: object
-      description: for providing geocoordinates as input criteria 
-      properties:
-        placeInputType:
-          type: string
-          enum:
-            - geoPositionInput
-        longitude:
-          $ref: "#/components/schemas/Longitude"
-        latitude:
-          $ref: "#/components/schemas/Latitude"
-
-        
+        geoPosition:
+          $ref: "#/components/schemas/GeoPosition"
     
     PlaceRef: ### OJP
-      oneOf:
-        - $ref: "#/components/schemas/StopPlaceRef"
-        - $ref: "#/components/schemas/PointOfInterestRef"
-        - $ref: "#/components/schemas/AddressRef"
-        - $ref: "#/components/schemas/FareConnectionPointRef"
-        - $ref: "#/components/schemas/GeoPosition"
-      discriminator:
-        propertyName: placeRefType
-
-    StopPlaceRef: ## OJP
       type: object
-      description: >-
-        Reference to a Stop Place using URNs to define code.
-        For UIC see UIC MERITS/TAP-TSI station codes. Provided by OJP.
-      required:
-        - stopPlaceRef
       properties:
-        placeRefType:
-          type: string
-          enum:
-            - stopPlaceRef
-        stopPlaceRef:
+        placeRef:
           $ref: "#/components/schemas/Link"
-
-    PointOfInterestRef: ## OJP
-      type: object
-      description: >-
-        Reference to a Point of Interest. Provided by OJP.
-      required:
-        - pointOfInterestRef
-      properties:
-        placeRefType:
-          type: string
-          enum:
-            - pointOfInterestRef
-        pointOfInterestRef:
-          $ref: "#/components/schemas/Link"
-
-    AddressRef: ## OJP
-      type: object
-      description: >-
-        Reference to an Address.
-      required:
-        - addressRef
-      properties:
-        placeRefType:
-          type: string
-          enum:
-            - addressRef
-        addressRef:
-          $ref: "#/components/schemas/Link"
-
-    FareConnectionPointRef:
-      type: object
-      description: >-
-        Reference to a Fare Connection Point.
-      required:
-        - fareConnectionPoint
-      properties:
-        placeRefType:
-          type: string
-          enum:
-            - fareConnectionPointRef
-        fareConnectionPointRef:
-          $ref: "#/components/schemas/Link"
-
+        geoPosition:
+          $ref: "#/components/schemas/GeoPosition"
+        
     ProductCategoryRef: ## OJP
       description: >-
         Reference to a product category. Product categories should be defined once and used
@@ -7640,7 +7530,7 @@ components:
         stations:
           type: array
           items:
-            $ref: "#/components/schemas/StopPlaceRef"
+            $ref: "#/components/schemas/PlaceRef"
           minItems: 1
 
     CarrierConstraint:
@@ -7744,7 +7634,7 @@ components:
           items:
             type: array
             items:
-              $ref: "#/components/schemas/StopPlaceRef" # EXT Changed from StopPoint
+              $ref: "#/components/schemas/PlaceRef" # EXT Changed from StopPoint
 
     TrainValidity:
       type: object
@@ -7799,10 +7689,6 @@ components:
         - latitude
         - longitude
       properties:
-        placeRefType:
-          type: string
-          enum:
-            - stopPlaceRef
         longitude:
           $ref: "#/components/schemas/Longitude"
         latitude:


### PR DESCRIPTION
Changed all placeref subtypes to a combination of geoposition and a link
Rationale:
* PlaceRef are supposed to be a reference. Since all kinds of places are resources (including fareconnectionpoints), they all have an id and a URI so it can be referred to
* rel & value element can help describe the link. value would typically be the urn of the place, but could be something else
Note: IMO it would be even better to completely get rid of the inheritance here and  just have placeref as a cominbaiton of geocoordinate and link. However that also implies that elements referring to a stopPlaceRef (such as the legboard) would now refer to a placeRef (not specifically a stopPlaceRef). That is an improvement to me but to be discussed 

Removed places from embed structures
Rationale:
* Since we removed the possibility to embed places, does not make sense to still propose it in the parameters 

Added a placeInput element 
Rationale
* Regardless of what we want  in addition, we cannot use the same structure for the input and output, as the key element of the output (since we now always work with a reference) is a link, and the key input should be an urn or a data structure 
* The new structure allows to specify either a geolocation, a urn for a place or a fareconnectionPoint. Note ideally we should only use URNs or geolocations here.
* Subsequently, I changed all the placerefs in requests for placeInputs
Note: again the proper solution would be to ensure all places in OSDM have an URN and only refere to places by their URN

Added transferleg specification for consistency but also to distinguish request and response structures

Also tripLegSpecification should be a oneOf/allOf structure to be consistent (did not do this change)