### PR TITLE
Pricing Mode in Offer request

### DIFF
--- a/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
+++ b/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
@@ -4580,6 +4580,9 @@ components:
         currency:
           $ref: "#/components/schemas/Currency"
           description: The currency returned might be different from the one requested.
+        pricingMode:
+          type: object
+          $ref: "#/components/schemas/PricingMode"
 
     OfferPartType:
       type: string
@@ -4967,17 +4970,25 @@ components:
         - SEMI_FLEXIBLE
         - NON_FLEXIBLE
 
+    PricingMode:
+      type: string
+      description: >-
+        Pricing mode applied to provide Offers for given criteria.
+        Distributor may specify which Pricing Mode is preferred though
+        the allocator, if not supporting given mode, reverts back to 
+        the other mode and provides warning instead.
+      enum:
+        - COLLECTIVE
+        - INDIVIDUAL
+
     CommonOfferPartAttributes:
       type: object
       properties:
         price:
           $ref: "#/components/schemas/Price"
         pricingMode:
-          type: string
-          enum:
-            - COLLECTIVE
-            - INDIVIDUAL
-          default: INDIVIDUAL
+          type: object
+          $ref: "#/components/schemas/PricingMode"
         appliedReductions:
           type: array
           items:

--- a/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
+++ b/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
@@ -4580,9 +4580,9 @@ components:
         currency:
           $ref: "#/components/schemas/Currency"
           description: The currency returned might be different from the one requested.
-        pricingMode:
+        offerMode:
           type: object
-          $ref: "#/components/schemas/PricingMode"
+          $ref: "#/components/schemas/OfferMode"
 
     OfferPartType:
       type: string
@@ -4970,13 +4970,15 @@ components:
         - SEMI_FLEXIBLE
         - NON_FLEXIBLE
 
-    PricingMode:
+    OfferMode:
       type: string
       description: >-
-        Pricing mode applied to provide Offers for given criteria.
-        Distributor may specify which Pricing Mode is preferred though
+        Offer Mode applied to provide Offers for given criteria.
+        Distributor may specify which Offer Mode is preferred though
         the allocator, if not supporting given mode, reverts back to 
-        the other mode and provides warning instead.
+        the other mode and provides warning instead. Individual Offer Mode 
+        means that each Passenger is given individual Admissions and Reservations
+        in order to allow to refund individual Passengers booked in single Booking.
       enum:
         - COLLECTIVE
         - INDIVIDUAL
@@ -4986,9 +4988,9 @@ components:
       properties:
         price:
           $ref: "#/components/schemas/Price"
-        pricingMode:
+        offerMode:
           type: object
-          $ref: "#/components/schemas/PricingMode"
+          $ref: "#/components/schemas/OfferMode"
         appliedReductions:
           type: array
           items:

--- a/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
+++ b/specification/v1.5.0-rc/OSDM-online-api-v1.5.0-rc.yml
@@ -4959,6 +4959,7 @@ components:
       x-extensible-enum:
         - FIRST
         - SECOND
+
     Flexibility:
       type: string
       x-extensible-enum:


### PR DESCRIPTION
Hello @schlpbch, I am providing PR as agreed last Friday. Pricing Mode enum was separated from CommonOfferPartAttributes and referenced. OfferSearchCriteria got pricingMode property. Both properties are optional. I have also dropped the default value INDIVIDUAL as there seemed not to be an agreement when is the overall default/standard across OSDM partners.