### PR TITLE
Added version 2.0.1 of OSDM online API due to issues in version 2.0.0

### DIFF
--- a/specification/v2.0.0/OSDM-online-api-v2.0.1.yml
+++ b/specification/v2.0.0/OSDM-online-api-v2.0.1.yml
@@ -1,0 +1,11293 @@
+openapi: 3.0.3
+
+info:
+  title: UIC 90918-10 - OSDM
+  version: 2.0.1
+  description: >-
+    Specifications for the OSDM API standard. The OSDM specification supports two modes of operation: Distributor Mode and Allocator Mode. The API works the same in both modes, except that in allocator mode the API also returns fare information.
+    The OSDM specification combines the allocator and distributor modes into one aligned API interface.
+  contact:
+    name: OSDM Working Group
+    url: 'https://osdm.io'
+    email: osdm@uic.org
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+
+servers:
+  - url: https://s3p-osdm.cloud.sqills.com
+    description: >-
+      Sqills Sandbox
+
+tags:
+  - name: Places
+    description: >-
+      resources to search for places
+  - name: Trips
+    description: >-
+      resources to search for trips
+  - name: Offers
+    description: >-
+      resources to get bookable offers
+  - name: Availabilities
+    description: >-
+      resources to query availabilities before or after pre-booking
+  - name: BookingPart
+    description: >-
+      resources to add and remove offer parts to a pre-booked booking
+  - name: Bookings
+    description: >-
+      resources to manipulate bookings
+  - name: On Hold
+    description: >-
+      resources to put a pre-booking on hold for a given time limit
+  - name: Bookings Search
+    description: >-
+      resources to search for bookings
+  - name: Passengers
+    description: >-
+      resources to manipulate a passenger's information at every stage of the flow
+  - name: Purchaser
+    description: >-
+      resources to manipulate a purchaser's information at every stage of the flow
+  - name: Fulfillments
+    description: >-
+      resources to retrieve fulfillments, e.g. tickets
+  - name: Refund
+    description: >-
+      resources to get and accept a refund offer
+  - name: Exchange
+    description: >-
+      resources to get exchange offers and book it
+  - name: Release
+    description: >-
+      resources to release 
+  - name: Complaint Management
+    description: >-
+      resources to manage complaints
+  - name: Master Data
+    description: >-
+      resources to get master data
+  - name: Cancel Fulfillments
+    description: >-
+      resources to cancel fulfillments
+  - name: Document
+    description: >-
+      resources to get documents
+  - name: Reimbursement Management
+    description: >-
+      resources to manage reimbursements
+
+paths:
+  /places:
+    get:
+      tags:
+        - Master Data
+      summary: Returns all places.
+      operationId: getPlaces
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: page
+          in: query
+          description: >-
+            can be used for pagination
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            the requested places
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    post:
+      tags:
+        - Places
+      summary: returns place information for a given place request
+      description: >-
+        Returns places for a given place request based on the OJP specification.
+      operationId: postPlaces
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+      requestBody:
+        description: >-
+          request for place
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlaceRequest'
+      responses:
+        '200':
+          description: >-
+            place information found matching criteria
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /places/{placeId}:
+    get:
+      tags:
+        - Places
+      summary: returns a place
+      operationId: getPlacesId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: placeId
+          in: path
+          description: >-
+            id of the place to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            the requested places
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /trips-collection:
+    post:
+      tags:
+        - Trips
+      summary: returns a collection of trips for a given OJP trip request
+      description: >-
+        Returns trips for a given trip request based on the OJP specification.
+      operationId: postTrips
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+      requestBody:
+        description: >-
+          request for trips
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TripSearchCriteria'
+      responses:
+        '200':
+          description: >-
+            trips found matching criteria
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripCollectionResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /trips-collection/{tripsCollectionId}:
+    get:
+      tags:
+        - Trips
+      summary: Returns a collection of trips for a specified origin and destination (and via).
+      description: >-
+        The unique codes of the origin and destination can be resolved using the places service.
+      operationId: getTripsCollectionId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: tripsCollectionId
+          in: path
+          description: >-
+            id of the trips
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          schema:
+            type: string
+        - name: embed
+          in: query
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+            Default value: ALL
+          schema:
+            type: array
+            maxItems: 2
+            items:
+              $ref: '#/components/schemas/TripsCollectionResponseContent'
+      responses:
+        '200':
+          description: >-
+            Trip(s) found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /trips/{tripId}:
+    get:
+      tags:
+        - Trips
+      summary: Returns a trip element representing a travel trip.
+      description: >-
+        A trip consists of one or more legs for a given tripId. Depending on the
+        embed either references or full location definitions is returned.
+      operationId: getTripsId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: tripId
+          in: path
+          description: >-
+            id of the trip to get.
+          required: true
+          schema:
+            type: string
+        - name: stopBehavior
+          in: query
+          description: >-
+            Influences what stops are to be returned in response
+            (ORIGIN_DESTINATION_ONLY returns no intermediate stops;
+            REAL_BOARDING_ALIGHTING returns all stops except virtual stops).
+            Default value: ORIGIN_DESTINATION_ONLY
+          schema:
+            $ref: '#/components/schemas/StopBehavior' 
+        - name: embed
+          in: query
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+            Default value: ALL
+          schema:
+            type: array
+            maxItems: 1
+            items:
+              $ref: '#/components/schemas/TripResponseContent'
+      responses:
+        '200':
+          description: >-
+            the requested trip
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /offers:
+    post:
+      tags:
+        - Offers
+      summary: Returns offers for trips or trip search criteria.
+      operationId: createOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OfferCollectionRequest'
+      responses:
+        '200':
+          description: >-
+            Collection of offer found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfferCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /booking/{bookingId}/onHoldOffer:
+    post:
+      tags:
+        - On Hold
+      summary: Creates an on hold offer.
+      operationId: createOnHoldOffer
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnHoldOfferRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnHoldOfferResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /booking/{bookingId}/onHoldOffer/{onHoldOfferId}:
+    patch:
+      tags:
+        - On Hold
+      summary: Confirms an on hold offer.
+      operationId: confirmOnHoldOffer
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: onHoldOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnHoldOfferPatchRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnHoldOfferResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/passengers/{passengerId}:
+    get:
+      tags:
+        - Passengers
+      summary: Returns the passenger's information at booking step.
+      operationId: getBookingPassengersId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: passengerId
+          in: path
+          description: >-
+            id of the passenger
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Passenger found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PassengerResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Passengers
+      summary: Allows updating a passenger's information at booking step.
+      operationId: patchBookingPassenger
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking the passenger is in.
+          required: true
+          schema:
+            type: string
+        - name: passengerId
+          in: path
+          description: >-
+            id of the passenger
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Passenger'
+      responses:
+        '200':
+          description: >-
+            Passenger successfully patched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PassengerResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/purchaser:
+    get:
+      tags:
+        - Purchaser
+      summary: Returns the purchaser's information at booking step.
+      operationId: getBookingPurchaser
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking the purchaser is in.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Purchaser found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurchaserResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Purchaser
+      summary: Allows updating a purchaser's information at booking step.
+      operationId: patchBookingPurchaser
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking the purchaser is in.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Purchaser'
+      responses:
+        '200':
+          description: >-
+            Purchaser successfully patched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurchaserResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/bookedOffer/{bookedOfferId}/reservations/{reservationId}:
+    patch:
+      tags:
+        - BookingPart
+      summary: Adds an optional reservation to a  prebooked booking.
+      operationId: patchBookingBookedOfferReservations
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bookedOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: reservationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookedOfferReservationPatchRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookedOfferReservationPatchResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - BookingPart
+      summary: Removes an optional reservation from pre-booked booking.
+      operationId: deleteBookingBookedOfferReservations
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bookedOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: reservationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/bookedOffer/{bookedOfferId}/ancillaries/{ancillaryId}:
+    patch:
+      tags:
+        - BookingPart
+      summary: Adds an ancillary to a pre-booked booking.
+      operationId: patchBookingBookedOfferAncillaries
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bookedOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ancillaryId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookedOfferAncilliaryPatchRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookedOfferAncillaryPatchResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - BookingPart
+      summary: Removes an ancillary from pre-booked booking.
+      operationId: deleteBookingBookedOfferAncillary
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: bookedOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: ancillaryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings:
+    post:
+      tags:
+        - Bookings
+      summary: Creates a booking based on a previously requested offer.
+      operationId: postBookings
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingRequest'
+      responses:
+        '200':
+          description: >-
+            Booking prebooked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}:
+    get:
+      tags:
+        - Bookings
+      summary: Returns a booking.
+      operationId: getBookingsId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to get.
+          required: true
+          schema:
+            type: string
+        - name: embed
+          in: query
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+            Default value: ALL
+          schema:
+            type: array
+            maxItems: 7
+            items:
+              $ref: '#/components/schemas/BookingResponseContent'
+      responses:
+        '200':
+          description: >-
+            booking found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Bookings
+      summary: Confirms a booking.
+      operationId: confirmBooking
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to be patched
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingPatchRequest'
+      responses:
+        '200':
+          description: >-
+            booking fulfillment type updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Bookings
+      summary: Deletes the booking.
+      description: >-
+        It is only possible before the booking is confirmed or in case of a technical problem in confirming multiple
+        independent bookings within a sales transaction. Deletes on a confirmed booking must be documented
+        and evidence on the issue must be provided on request.
+        The delete on a confirmed booking is allowed immediately after the confirmation of the booking,
+        but must be repeated according to the error handling rules in case the delete fails.
+      operationId: deleteBookingsId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to delete.
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/bookedOffer:
+    get:
+      tags:
+        - Bookings
+      summary: Get booked offer for a given booking.
+      operationId: getBookingBookedOffer
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookedOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings-search:
+    post:
+      tags:
+        - Bookings Search
+      summary: Search for bookings based on search parameters.
+      operationId: searchBookings
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: page
+          in: query
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingSearchRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingSearchResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/fulfillments:
+    post:
+      tags:
+        - Fulfillments
+      summary: Confirms the booking a triggers the fulfillment of the booking, does not return the fulfillments.
+      operationId: postFulfillments
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to be patched
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Fulfillment successfully completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FulfillmentCollectionResponse'
+    
+        '202':
+          $ref: '#/components/responses/FulfillmentRequestAcceptedResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Fulfillments
+      summary: Finalizes the fulfillments and returns the documents.
+      operationId: finalizeFulfillment
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to be patched
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FulfillmentPatchRequest'
+      responses:
+        '200':
+          description: >-
+            Fulfillment successfully completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FulfillmentCollectionResponse'
+    
+        '202':
+          $ref: '#/components/responses/FulfillmentRequestAcceptedResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /fulfillments/{fulfillmentId}:
+    get:
+      tags:
+        - Fulfillments
+      summary: Returns the fulfillment, aka. ticket for the provided id.
+      operationId: getFulfillmentId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: fulfillmentId
+          in: path
+          description: >-
+            id of the fulfillment to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            fulfillment found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FulfillmentResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Fulfillments
+      summary: Activates a fulfillment, i.e. changes the status to AVAILABLE.
+      description: >-
+        Changes the fulfillment to status AVAILABLE. In the case of multi-journey product, one of the fulfillment is now "activated" and can be used to travel.
+      operationId: patchFulfillment
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: fulfillmentId
+          in: path
+          description: >-
+            patch the fulfillment
+          required: true
+          schema:
+            $ref: '#/components/schemas/FulfillmentActivationPatchRequest' 
+      responses:
+        '200':
+          description: >-
+            fulfillment patched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FulfillmentResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/refundOffers:
+    post:
+      tags:
+        - Refund
+      summary: Initiates a refund process by creating a refundOffer resource.
+      description: >-
+        The RefundOffer contains the required information on the potential operation. One refund offer can then be
+        accepted via a PATCH, deleted or left to die at the end of its lifetime.
+      operationId: postRefundOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundOfferRequest'
+      responses:
+        '200':
+          description: >-
+            Refund offer created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundOfferCollectionResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/refundOffers/{refundOfferId}:
+    get:
+      tags:
+        - Refund
+      summary: Returns the refund offer for the ids provided.
+      operationId: getRefundOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: refundOfferId
+          in: path
+          description: >-
+            id of the refund offer to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            RefundOffer found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Refund
+      summary: Allows to accept and confirm a refund offer.
+      operationId: patchRefundOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: refundOfferId
+          in: path
+          description: >-
+            id of the refund offer
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundOfferPatchRequest'
+      responses:
+        '200':
+          description: >-
+            RefundOffer confirmed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RefundOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Refund
+      summary: Deletes a refundOffer without waiting for expiry.
+      operationId: deleteRefundOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: refundOfferId
+          in: path
+          description: >-
+            id of the refund offer
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/releaseOffers:
+    post:
+      tags:
+        - Release
+      summary: Initiates a release process by creating a releaseOffers resource.
+      operationId: postReleaseOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReleaseOfferRequest'
+      responses:
+        '200':
+          description: >-
+            Refund offer created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReleaseOfferCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/releaseOffers/{releaseOfferId}:
+    get:
+      tags:
+        - Release
+      summary: Returns the release offer for the ids provided.
+      operationId: getReleaseOffer
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: releaseOfferId
+          in: path
+          description: >-
+            id of the refund offer to get.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            RefundOffer found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReleaseOfferResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Release
+      summary: Allows to accept and confirm a release offer.
+      operationId: patchReleaseOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: releaseOfferId
+          in: path
+          description: >-
+            id of the refund offer
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReleaseOfferPatchRequest'
+      responses:
+        '200':
+          description: >-
+            RefundOffer confirmed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReleaseOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Release
+      summary: Deletes a release offer without waiting for expiry.
+      operationId: deleteReleaseOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: releaseOfferId
+          in: path
+          description: >-
+            id of the refund offer
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/cancelFulfillmentsOffers:
+    post:
+      tags:
+        - Cancel Fulfillments
+      summary: Initiates a cancel fulfillments process by creating a cancelFulfillmentsOffers resource.
+      operationId: postCancelFulfillmentsOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelFulfillmentsOfferRequest'
+      responses:
+        '200':
+          description: >-
+            Refund offer created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelFulfillmentsOfferCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/cancelFulfillmentsOffers/{cancelFulfillmentsOfferId}:
+    get:
+      tags:
+        - Cancel Fulfillments
+      summary: Returns the cancel fulfillments offer for the ids provided.
+      operationId: getCancelFulfillmentOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: cancelFulfillmentsOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            RefundOffer found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelFulfillmentsOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Cancel Fulfillments
+      summary: Allows to accept and confirm a cancel fulfillments offer.
+      operationId: patchCancelFulfillmentsOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: cancelFulfillmentsOfferId
+          in: path
+          description: >-
+            id of the refund offer
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelFulfillmentsOfferPatchRequest'
+      responses:
+        '200':
+          description: >-
+            RefundOffer confirmed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelFulfillmentsOfferResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Cancel Fulfillments
+      summary: Deletes a cancel fulfillments offer without waiting for expiry.
+      operationId: deleteCancelFulfillmentOffers
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+        - name: cancelFulfillmentsOfferId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/exchangeOperations/{exchangeOperationId}:
+    get:
+      tags:
+        - Exchange
+      summary: Returns the exchange operation with the id provided. It may be a provisional or a confirmed exchange.
+      operationId: getBookingExchangeOperations
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: exchangeOperationId
+          in: path
+          description: >-
+            id of the exchange operation
+          required: true
+          schema:
+            type: string
+        - name: embed
+          in: query
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+            Default value: ALL
+          schema:
+            type: array
+            maxItems: 5
+            items:
+              $ref: '#/components/schemas/ExchangeOperationResponseContent'
+      responses:
+        '200':
+          description: >-
+            ExchangeOperation found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExchangeOperationResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Exchange
+      summary: Allows to update an ongoing exchange operation.
+      operationId: patchExchangeOperation
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking to be exchanged.
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: exchangeOperationId
+          in: path
+          description: >-
+            id of the exchange operation.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExchangeOperationPatchRequest'
+      responses:
+        '200':
+          description: >-
+            Exchange successfully completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExchangeOperationResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Exchange
+      summary: Cancels an ongoing exchange operation in provisional state.
+      operationId: deleteExchangeOperation
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          description: >-
+            id of the booking containing the exchange operation
+          required: true
+          schema:
+            type: string
+        - name: exchangeOperationId
+          in: path
+          description: >-
+            id of the exchangeOperation to delete.
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /exchange-offers:
+    post:
+      tags:
+        - Exchange
+      summary: Returns exchange offers for a specified fulfillments submitted given requested new trip characteristics.
+      operationId: createExchangeOffersCollection
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: pEmbed
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ExchangeOfferCollectionResponseContent' 
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExchangeOfferCollectionRequest'
+      responses:
+        '200':
+          description: >-
+            Collection of exchange offers found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExchangeOfferCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /complaints:
+    post:
+      tags:
+        - Complaint Management
+      summary: Allows adding a complaint.
+      description: >-
+        Create a complaint request for part of a booking.
+      operationId: createComplaint
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Complaint'
+      responses:
+        '200':
+          description: >-
+            complaint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplaintResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /complaints/{complaintId}:
+    get:
+      tags:
+        - Complaint Management
+      summary: Returns a complaint.
+      description: >-
+        Get a complaint including its current state.
+      operationId: getComplaint
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: complaintId
+          in: path
+          description: >-
+            id of the complaint
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            the requested complaint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplaintResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Complaint Management
+      summary: Allows updating a complaint.
+      description: >-
+        Update a complaint request, i.e add missing documents or change state.
+      operationId: patchComplaint
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: complaintId
+          in: path
+          description: >-
+            id of the complaint to be patched
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComplaintPatchRequest'
+      responses:
+        '200':
+          description: >-
+            complaint updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplaintResponse'
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /coachLayouts:
+    get:
+      tags:
+        - Master Data
+      summary: Returns all coach layouts.
+      description: >-
+        Retrieve the coach layout description needed for graphical reservation. The coach
+        layouts can either be retrieved as a complete list or specificity for a train identified via offerId and reservationId or fareId
+      operationId: getCoachLayouts
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            coach layouts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoachLayoutCollectionResponse'
+          headers:
+            Expires:
+              schema:
+                type: string
+                description: >-
+                  Gives the date/time after which the response is considered stale (in 'HTTP-date' format as defined by RFC 7231).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /coachLayouts/{layoutId}:
+    get:
+      tags:
+        - Master Data
+      summary: Returns a coach layout for a provided id.
+      description: >-
+        Retrieve a coach layout description needed for graphical reservation for a given layout id.
+      operationId: getCoachLayoutsLayoutId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: layoutId
+          in: path
+          description: >-
+            id of the layout
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            coach layouts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoachLayoutResponse'
+          headers:
+            Expires:
+              schema:
+                type: string
+                description: >-
+                  Gives the date/time after which the response is considered stale (in 'HTTP-date' format as defined by RFC 7231).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /reductionCards:
+    get:
+      tags:
+        - Master Data
+      summary: Returns all reduction card definitions.
+      description: >-
+        returns a collection of reduction card definitions
+      operationId: getReductionCards
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Reduction cards provided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReductionCardCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+            Expires:
+              schema:
+                type: string
+                description: >-
+                  Gives the date/time after which the response is considered stale (in 'HTTP-date' format as defined by RFC 7231).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /zones:
+    get:
+      tags:
+        - Master Data
+      summary: Returns all zone definitions.
+      operationId: getZones
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            zones provided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+            Expires:
+              schema:
+                type: string
+                description: >-
+                  Gives the date/time after which the response is considered stale (in 'HTTP-date' format as defined by RFC 7231).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/documents:
+    post:
+      tags:
+        - Document
+      summary: Allows adding a document to a booking.
+      operationId: createDocuments
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/documents/{documentId}:
+    get:
+      tags:
+        - Document
+      summary: returns a document from a booking
+      operationId: getDocument
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    delete:
+      tags:
+        - Document
+      summary: Delete a document from a booking.
+      operationId: deleteBookingsDocumentsId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - $ref: '#/components/parameters/idempotencyKey'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: documentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+    
+        '204':
+          $ref: '#/components/responses/NoContentResponse'
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/reimbursements:
+    post:
+      tags:
+        - Reimbursement Management
+      summary: Create reimbursement for a booking.
+      description: >-
+        Create a reimbursement request for part of a booking.
+      operationId: createReimbursement
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReimbursementRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReimbursementResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /bookings/{bookingId}/reimbursements/{reimbursementId}:
+    get:
+      tags:
+        - Reimbursement Management
+      summary: Get reimbursement of a booking.
+      description: >-
+        Get reimbursement including its current state.
+      operationId: getReimbursement
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: reimbursementId
+          in: path
+          required: true
+          schema:
+            type: string
+            nullable: false
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReimbursementResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+    patch:
+      tags:
+        - Reimbursement Management
+      summary: Update reimbursement of a booking.
+      description: >-
+        Update a reimbursement request, i.e add missing documents or change state.
+      operationId: updateReimbursement
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: bookingId
+          in: path
+          required: true
+          schema:
+            type: string
+            nullable: false
+        - name: reimbursementId
+          in: path
+          required: true
+          schema:
+            type: string
+            nullable: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReimbursementPatchRequest'
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReimbursementResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /availabilities/placeMap:
+    get:
+      tags:
+        - Availabilities
+      summary: Get place map including availabilities.
+      description: >-
+        Get place map including availabilities.
+      operationId: getAvailabilitiesPlaceMap
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: contextId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: contextType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContextType' 
+        - name: resourceId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceType' 
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceAvailabilityResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /availabilities/nearby:
+    get:
+      tags:
+        - Availabilities
+      summary: Get availabilities nearby a given place.
+      description: >-
+        Get availabilities nearby a given place.
+      operationId: getAvailabilitiesNearby
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: contextId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: contextType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContextType' 
+        - name: resourceId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceType' 
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceAvailabilityCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /availabilities/preferences:
+    get:
+      tags:
+        - Availabilities
+      summary: Get availabilities for a set of preferences.
+      description: >-
+        Get availabilities for a set of preferences.
+      operationId: getAvailabilitiesPreferences
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: contextId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: contextType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContextType' 
+        - name: resourceId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceType' 
+      responses:
+        '200':
+          description: >-
+            TODO: Please add comment for response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceAvailabilityCollectionResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /products:
+    get:
+      tags:
+        - Master Data
+      summary: Returns all products.
+      operationId: getProducts
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: page
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Product found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductCollectionResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+  /products/{productId}:
+    get:
+      tags:
+        - Master Data
+      summary: Returns a product for the provided id.
+      operationId: getProductsId
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: productId
+          in: path
+          description: >-
+            id of the product to get
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: >-
+            Product found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductResponse'
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                default: 'public, max-age=10000'
+                description: >-
+                  Resource is fairly persistent and has a medium time to live to allow short-term caching.
+            Content-Language:
+              schema:
+                type: string
+                description: >-
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+    
+    
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
+
+
+security:
+  - oAuth2ClientCredentials: []
+
+components:
+  securitySchemes:
+    oAuth2ClientCredentials:
+      type: oauth2
+      description: >-
+        See https://swagger.io/docs/specification/authentication/oauth2/
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://login.microsoftonline.com/tbd'
+          refreshUrl: 'https://refresh.url/tbd'
+          scopes: {}
+
+  parameters:
+    acceptLanguage:
+      name: Accept-Language
+      in: header
+      description: >-
+        Describes the set of natural languages that are preferred for localized text in the response
+        to the request (see RFC2616-sec14.4). Supporting English (en) is a must.
+      schema:
+        type: string
+
+    idempotencyKey:
+      name: Idempotency-Key
+      in: header
+      description: >-
+        The HTTP Idempotency request header field can be used to carry idempotency key in order to make
+        non-idempotent HTTP methods such as POST or PATCH fault-tolerant.
+      schema:
+        type: string
+
+    requestor:
+      name: Requestor
+      in: header
+      description: >-
+        The requestor header contains detailed information about who is calling the API. It can include information such as channel, organization, sales unit or workstation id and be used to configure e.g. the fare range provided to the caller. The content of the string is part of a bilateral contract by the two parties and not standardized by OSDM. It is recommend to encrypt the information transferred.
+      schema:
+        type: string
+      required: true
+
+    traceParent:
+      name: traceparent
+      in: header
+      description: >-
+        The traceparent header describes the position of the incoming request in its trace graph in a portable,
+        fixed-length format. Its design focuses on fast parsing. Every tracing tool MUST properly set
+        traceparent even when it only relies on vendor-specific information in tracestate (see W3C Trace Context).
+      schema:
+        type: string
+
+    traceState:
+      name: tracestate
+      in: header
+      description: >-
+        The tracestate extends traceparent with vendor-specific data represented by a set of name/value pairs.
+        Storing information in tracestate is optional (see W3C Trace Context).
+      schema:
+        type: string
+
+  responses:
+    NoContentResponse:
+      description: >-
+        No Content (204)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    BadRequestResponse:
+      description: >-
+        Bad Request (400)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    UnauthorizedResponse:
+      description: >-
+        Unauthorized (401)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    ForbiddenResponse:
+      description: >-
+        Forbidden (403)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    NotFoundResponse:
+      description: >-
+        Not Found (404)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    NotAcceptableResponse:
+      description: >-
+        Not Acceptable (406)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    ConflictResponse:
+      description: >-
+        Conflict (409)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    UnsupportedMediaTypeResponse:
+      description: >-
+        Unsupported Media Type (415)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    InternalServerErrorResponse:
+      description: >-
+        Internal Server Error (500)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    NotImplementedResponse:
+      description: >-
+        Not Implemented (501)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    ServiceUnavailableResponse:
+      description: >-
+        Service Unavailable (503)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    DefaultErrorResponse:
+      description: >-
+        default error response
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    FulfillmentRequestAcceptedResponse:
+      description: >-
+        Fulfillment successfully initiated, retrieve booking to retrieve the fulfillment documents
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WarningCollection'
+
+
+  schemas:
+    WarningCollection:
+      type: object
+      additionalProperties: false
+      description: >-
+        List of warnings.
+        
+      properties:
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Warning'
+
+    Warning:
+      type: object
+      additionalProperties: false
+      description: >-
+        This element can be used to pass non-blocking information or events,
+        such as a price difference with the initially offered price at booking time.
+        It is inspired on the JSon problem structure.
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          nullable: false
+        type:
+          description: >-
+            An absolute URI that identifies the warning type. When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          type: string
+          format: uri
+          default: 'about:blank'
+          example: https://example.com/warns/price-updated
+        detail:
+          description: >-
+            A human readable explanation specific to this occurrence of the
+            warning.
+          type: string
+          example: The price of the given offer part has been updated during the booking operation
+        instance:
+          description: >-
+            An absolute URI that identifies the specific occurrence of the warning.
+          type: string
+          format: uri
+          example: offers/offer1234
+
+    PlaceResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - places
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/Place'
+          minItems: 1
+
+    TripResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - trip
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        trip:
+          $ref: '#/components/schemas/Trip'
+
+    PlaceRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Initial input for the place information request. This input defines what is originally looked for.
+        Provided by OJP.
+      properties:
+        placeInput:
+          $ref: '#/components/schemas/InitialPlaceInput'
+        restrictions:
+          $ref: '#/components/schemas/PlaceParam'
+
+    PlaceParam:
+      type: object
+      additionalProperties: false
+      description: >-
+        More parameters for restricting the request. Provided by OJP.
+      properties:
+        type:
+          $ref: '#/components/schemas/PlaceType'
+        usage:
+          $ref: '#/components/schemas/PlaceUsage'
+        ptModes:
+          $ref: '#/components/schemas/ModeFilter'
+        serviceBrandFilter:
+          $ref: '#/components/schemas/ServiceBrandFilter'
+        carrierFilter:
+          $ref: '#/components/schemas/CarrierFilter'
+        pointOfInterestFilter:
+          $ref: '#/components/schemas/PointOfInterestFilter'
+        numberOfResults:
+          description: >-
+            Maximum number of results to be returned. The service is allowed to return fewer objects if reasonable
+            or otherwise appropriate.
+          type: integer
+          format: int32
+          minimum: 1
+
+    PlaceType:
+      description: >-
+        Provided by OJP.
+      type: string
+      enum:
+        - STOP
+        - ADDRESS
+        - POI
+        - GEO_COORDINATE
+        - TOPOGRAPHIC_PLACE
+
+    PlaceUsage:
+      description: >-
+        Provided by OJP.
+      type: string
+      enum:
+        - ORIGIN
+        - VIA
+        - DESTINATION
+
+    InitialPlaceInput:
+      type: object
+      additionalProperties: false
+      description: >-
+        Initial input for the place information request. This input defines what is originally looked for.
+        Provided by OJP.
+      properties:
+        name:
+          description: >-
+            Name of the place object which is looked after. This is usually the user's input. If not given,
+            the name of the resulting place objects is not relevant.
+          type: string
+          example: Bern Bärengraben
+        geoPosition:
+          $ref: '#/components/schemas/GeoPosition'
+
+    TripSearchCriteria:
+      type: object
+      additionalProperties: false
+      description: >-
+        Trip request structure. Provided by OJP.
+      required:
+        - origin
+        - destination
+      properties:
+        departureTime:
+          type: string
+          format: date-time
+        arrivalTime:
+          description: >-
+            requested arrival time. If arrival time is provided the departure time must be omitted.
+          type: string
+          format: date-time
+        origin:
+          $ref: '#/components/schemas/PlaceRef'
+        destination:
+          $ref: '#/components/schemas/PlaceRef'
+        vias:
+          description: >-
+            Ordered series of points where the journey must pass through. If more
+            than one via point is given all of them must be obeyed - in the correct
+            order. The server is allowed to replace a via stop by equivalent stops.
+          type: array
+          items:
+            $ref: '#/components/schemas/TripVia'
+        parameters:
+          $ref: '#/components/schemas/TripParameters'
+        embed:
+          description: >-
+            Influences whether referenced resources are returned in full or as references only. Proposed default ALL
+          type: array
+          items:
+            $ref: '#/components/schemas/TripsCollectionResponseContent'
+        returnSearchParameters:
+          $ref: '#/components/schemas/ReturnSearchParameters'
+
+    TripVia:
+      type: object
+      additionalProperties: false
+      description: >-
+        Via restrictions for a trip. Provided by OJP.
+      required:
+        - viaPoint
+      properties:
+        viaPoint:
+          $ref: '#/components/schemas/PlaceRef'
+        dwellTime:
+          description: >-
+            desired dwell time at the via place
+          type: string
+          format: duration
+          example: 30M
+
+    BaseTripPolicyFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Policies that control the trip search behavior for both public and individual transport.
+        Provided by OJP.
+      properties:
+        noSingleStep:
+          description: >-
+            The user is not able to climb one step, i.e. wheel chair.
+          type: boolean
+          default: false
+        noSight:
+          description: >-
+            The user is not able to see.
+          type: boolean
+          default: false
+
+    TripMobilityFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Base mobility options to be applied for both public and individual transport.
+        Provided by OJP.
+      properties:
+        bikeTransport:
+          description: >-
+            The user wants to carry a bike on public transport.
+          type: boolean
+          default: false
+        walkSpeed:
+          description: >-
+            Deviation from average walk speed in percent. 100% percent is average speed.
+          type: integer
+          format: int32
+          default: 100
+        additionalTransferTime:
+          description: >-
+            Additional time added to all transfers (also to transfers between individual to
+            public transport).
+          type: string
+          format: duration
+          example: 0S
+        minimalTransferTime:
+          type: string
+          format: duration
+
+    ModeFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        List of public transport modes to include or exclude. Provided by OJP.
+      properties:
+        exclude:
+          description: >-
+            Whether modes in list are to include or exclude from search.
+          type: boolean
+          default: true
+        transportModes:
+          description: >-
+            List of Transport modes to include/exclude.
+          type: array
+          items:
+            $ref: '#/components/schemas/Mode'
+
+    CarrierFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Filter for in/exclusion of carriers. Provided by OJP.
+      properties:
+        exclude:
+          description: >-
+            Whether carrier in list are to include or exclude from search.
+          type: boolean
+          default: true
+        carriers:
+          description: >-
+            Reference to carrier
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyRef'
+
+    ServiceBrandFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Filter for in/exclusion of service brands. Provided by OJP.
+      properties:
+        exclude:
+          description: >-
+            Whether service brand in list are to include or exclude from search.
+          type: boolean
+          default: true
+        serviceBrands:
+          description: >-
+            Reference to service brand codes
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBrandCode'
+
+    VehicleFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Filter for in/exclusion of vehicle based on vehicle number or line number.
+      properties:
+        exclude:
+          description: >-
+            Whether vehicle in list is to include or exclude from search.
+          type: boolean
+          default: true
+        vehicleNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/VehicleNumber'
+        lineNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineNumber'
+
+    PointOfInterestFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Filter POIs by category. Provided by OJP.
+      properties:
+        exclude:
+          description: >-
+            Whether carriers are to be included or excluded from the filtering.
+          type: boolean
+          default: true
+        pointOfInterestCategory:
+          description: >-
+            These POI categories can be used to filter POIs. If more than one is given the filtering
+            is by logical 'OR' (when Exclude=FALSE) and logical 'AND' (when Exclude=TRUE).
+          type: array
+          items:
+            $ref: '#/components/schemas/PointOfInterestCategory'
+
+    TripDataFilter:
+      type: object
+      additionalProperties: false
+      description: >-
+        Data to be included/excluded from search, f.e. modes, carriers. Provided by OJP.
+      properties:
+        ptModeFilter:
+          $ref: '#/components/schemas/ModeFilter'
+        carrierFilter:
+          $ref: '#/components/schemas/CarrierFilter'
+        serviceBrandFilter:
+          $ref: '#/components/schemas/ServiceBrandFilter'
+        vehicleFilter:
+          $ref: '#/components/schemas/VehicleFilter'
+
+    TripParameters:
+      type: object
+      additionalProperties: false
+      description: >-
+        Options to control the search behavior and response contents.
+        number of results > either number of results or number of results before and after are used.
+        Provided by OJP.
+      properties:
+        dataFilter:
+          $ref: '#/components/schemas/TripDataFilter'
+        policyFilter:
+          $ref: '#/components/schemas/BaseTripPolicyFilter'
+        mobilityFilter:
+          $ref: '#/components/schemas/TripMobilityFilter'
+        numberOfResults:
+          type: integer
+          format: int32
+          default: 5
+        numberOfResultsBefore:
+          type: integer
+          format: int32
+          default: 0
+        numberOfResultsAfter:
+          type: integer
+          format: int32
+          default: 5
+        ignoreRealtimeData:
+          type: boolean
+          default: false
+        transferLimit:
+          description: >-
+            The maximum number of interchanges the user will accept per trip.
+          type: integer
+          format: int32
+          minimum: 0
+        itModesToCover:
+          $ref: '#/components/schemas/IndividualMode'
+
+    TripCollectionResponse:
+      type: object
+      additionalProperties: false
+      description: >-
+        Trip response structure. Provided by OJP.
+      required:
+        - id
+      properties:
+        warning:
+          $ref: '#/components/schemas/WarningCollection'
+        id:
+          type: string
+          nullable: false
+        trips:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trip'
+        tripSummaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripSummary'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    Trip:
+      type: object
+      additionalProperties: false
+      description: >-
+        A complete trip from origin to destination. Provided by OJP.
+      required:
+        - id
+        - duration
+        - direction
+        - startTime
+        - endTime
+        - transfers
+        - legs
+      properties:
+        id:
+          description: >-
+            Id of this trip for referencing purposes. Unique within a trip.
+          type: string
+          nullable: false
+        externalRef:
+          description: >-
+            External reference of this trip for referencing purposes.
+          type: string
+        summary:
+          description: >-
+            A human-readable description of the trip.
+          type: string
+        duration:
+          description: >-
+            Overall duration of the trip
+          type: string
+          format: duration
+          nullable: false
+          example: PT20M
+        direction:
+          $ref: '#/components/schemas/TripDirectionType'
+        origin:
+          $ref: '#/components/schemas/PlaceRef'
+        destination:
+          $ref: '#/components/schemas/PlaceRef'
+        startTime:
+          description: >-
+            Departure time at origin.
+          type: string
+          format: date-time
+          nullable: false
+        endTime:
+          description: >-
+            Arrival time at destination
+          type: string
+          format: date-time
+          nullable: false
+        transfers:
+          description: >-
+            Number of interchanges
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        distance:
+          description: >-
+            Distance in meters over the the complete trip, i.e., including transfer legs.
+          type: integer
+          format: int32
+          minimum: 0
+        legs:
+          description: >-
+            Legs ot the trip
+          type: array
+          items:
+            $ref: '#/components/schemas/TripLeg'
+          minItems: 1
+        operatingDays:
+          $ref: '#/components/schemas/OperatingDays'
+        operatingDaysDescription:
+          description: >-
+            Textual description of the operation days, e.g. 'Monday to Friday' or 'Not on holidays'.
+          type: string
+        situationFullRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/SituationFullRef'
+        tripStatus:
+          $ref: '#/components/schemas/TripStatus'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    TripSummary:
+      type: object
+      additionalProperties: false
+      description: >-
+        Trip summary. Provided by OJP.
+      required:
+        - id
+        - startTime
+        - endTime
+        - duration
+        - destination
+        - transfers
+        - distance
+      properties:
+        id:
+          description: >-
+            Id of this trip for referencing purposes. Unique within trip response.
+          type: string
+          nullable: false
+        startTime:
+          description: >-
+            Departure time at origin.
+          type: string
+          format: date-time
+          nullable: false
+        endTime:
+          description: >-
+            Arrival time at destination.
+          type: string
+          format: date-time
+          nullable: false
+        duration:
+          description: >-
+            Overall duration of the trip.
+          type: string
+          format: duration
+          nullable: false
+        origin:
+          $ref: '#/components/schemas/PlaceRef'
+        destination:
+          $ref: '#/components/schemas/PlaceRef'
+        transfers:
+          type: integer
+          format: int32
+          nullable: false
+        distance:
+          type: integer
+          format: int32
+          nullable: false
+
+    TripStatus:
+      type: object
+      additionalProperties: false
+      properties:
+        unplanned:
+          description: >-
+            Whether this trip is an additional one that has not been planned.
+          type: boolean
+          default: false
+        cancelled:
+          description: >-
+            Whether this trip is cancelled and will not be run.
+          type: boolean
+          default: false
+        deviation:
+          description: >-
+            Whether this trip deviates from the planned service pattern.
+          type: boolean
+          default: false
+        delayed:
+          description: >-
+            Whether this trip is delayed.
+          type: boolean
+          default: false
+        infeasible:
+          description: >-
+            Whether this trip cannot be used, due to operational delays and impossible transfers.
+          type: boolean
+          default: false
+
+    TripSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        A minimal trip specification from origin to destination.
+      required:
+        - legs
+        - isPartOfInternationalTrip
+      properties:
+        externalRef:
+          description: >-
+            External reference of this trip for referencing purposes. Unique within a trip specification.
+          type: string
+        legs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripLegSpecification'
+          minItems: 1
+        isPartOfInternationalTrip:
+          type: boolean
+          nullable: false
+          default: false
+
+    OperatingDays:
+      type: object
+      additionalProperties: false
+      description: >-
+        Day of public transport operation of which the characteristics are defined in a specific
+        service calendar and which may last more than 24 hours. Provided by OJP.
+      required:
+        - from
+        - until
+        - pattern
+      properties:
+        from:
+          description: >-
+            Start date of period
+          type: string
+          format: date-time
+          nullable: false
+        until:
+          description: >-
+            End date of period
+          type: string
+          format: date-time
+          nullable: false
+        pattern:
+          description: >-
+            Bit pattern for operating days between start date and end date.
+            The length of the pattern is equal to the number of days from
+            start date to end date. A bit value of '1' indicates that an event
+            actually happens on the day that is represented by the bit position.
+          type: string
+          nullable: false
+
+    TripLeg:
+      type: object
+      additionalProperties: false
+      description: >-
+        A single stage of a trip that is made without change of MODE or service (ie:
+        between each interchange). Provided by OJP.
+      required:
+        - id
+      properties:
+        id:
+          description: >-
+            Id of this trip leg. Unique within trip result. A seqId is a leg id.
+          type: string
+          nullable: false
+        externalRef:
+          description: >-
+            External reference of this tripLeg for referencing purposes.
+          type: string
+        timedLeg:
+          $ref: '#/components/schemas/TimedLeg'
+        transferLeg:
+          $ref: '#/components/schemas/TransferLeg'
+        continuousLeg:
+          $ref: '#/components/schemas/ContinuousLeg'
+
+    TripLegSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        A minimal trip leg specification.
+      properties:
+        externalRef:
+          description: >-
+            External reference of this trip leg. Unique within trip result.
+          type: string
+        timedLeg:
+          $ref: '#/components/schemas/TimedLegSpecification'
+        transferLeg:
+          $ref: '#/components/schemas/TransferLeg'
+
+    TimedLeg:
+      type: object
+      additionalProperties: false
+      description: >-
+        A leg which is bound to a timetabled schedule. Corresponds to a ride. Provided by OJP.
+      required:
+        - start
+        - end
+        - service
+      properties:
+        start:
+          $ref: '#/components/schemas/Board'
+        intermediates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Intermediate'
+        end:
+          $ref: '#/components/schemas/Alight'
+        service:
+          $ref: '#/components/schemas/DatedJourney'
+        operatingDays:
+          $ref: '#/components/schemas/OperatingDays'
+        operatingDaysDescription:
+          description: >-
+            Textual description of the operation days, e.g. 'Monday to Friday' or 'not on holidays'.
+          type: string
+        duration:
+          type: string
+          format: duration
+        co2Emission:
+          $ref: '#/components/schemas/Quantity'
+
+    TimedLegSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        A minimal timed leg specification.
+      required:
+        - start
+        - end
+        - service
+      properties:
+        start:
+          $ref: '#/components/schemas/BoardSpecification'
+        intermediates:
+          type: array
+          items:
+            $ref: '#/components/schemas/IntermediateSpecification'
+        end:
+          $ref: '#/components/schemas/AlightSpecification'
+        service:
+          $ref: '#/components/schemas/DatedJourney'
+
+    TransferLeg:
+      type: object
+      additionalProperties: false
+      description: >-
+        A leg which links other legs of a trip where a transfer between different places is required.
+        Provided by OJP.
+      required:
+        - start
+        - end
+      properties:
+        continuousMode:
+          $ref: '#/components/schemas/ContinuousMode'
+        transferMode:
+          $ref: '#/components/schemas/TransferMode'
+        start:
+          $ref: '#/components/schemas/PlaceRef'
+        end:
+          $ref: '#/components/schemas/PlaceRef'
+        timeWindowStart:
+          description: >-
+            Time at which window begins.
+          type: string
+          format: date-time
+        timeWindowEnd:
+          description: >-
+            Time at which window ends.
+          type: string
+          format: date-time
+        duration:
+          description: >-
+            Overall duration of this interchange.
+          type: string
+          format: duration
+          example: PT20M
+        situationFullRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/SituationFullRef'
+        co2Emission:
+          $ref: '#/components/schemas/Quantity'
+
+    ContinuousLeg:
+      type: object
+      additionalProperties: false
+      description: >-
+        A leg of a journey that is not bound to a timetable. Provided by OJP.
+      required:
+        - start
+        - end
+        - service
+      properties:
+        start:
+          $ref: '#/components/schemas/Place'
+        end:
+          $ref: '#/components/schemas/Place'
+        service:
+          $ref: '#/components/schemas/ContinuousService'
+        timeWindowStart:
+          description: >-
+            Time at which window begins.
+          type: string
+          format: date-time
+        timeWindowEnd:
+          description: >-
+            Time at which window ends.
+          type: string
+          format: date-time
+        duration:
+          description: >-
+            Duration of this leg according to user preferences like walk speed.
+          type: string
+          format: duration
+          example: 1800S
+        situationFullRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/SituationFullRef'
+        co2Emission:
+          $ref: '#/components/schemas/Quantity'
+
+    ContinuousService:
+      type: object
+      additionalProperties: false
+      description: >-
+        A vehicle movement on a continuous, non-timetabled service.
+        Service of this leg. May be 'walk' in most cases, but also cycling or taxi etc.
+        Provided by OJP.
+      required:
+        - operatingDayRef
+        - journeyRef
+        - mode
+        - publishedServiceName
+        - originText
+        - destinationText
+      properties:
+        continuousMode:
+          $ref: '#/components/schemas/ContinuousMode'
+        individualMode:
+          $ref: '#/components/schemas/IndividualMode'
+        operatingDayRef:
+          $ref: '#/components/schemas/OperationDayRef'
+        journeyRef:
+          $ref: '#/components/schemas/JourneyRef'
+        mode:
+          type: string
+          nullable: false
+          example: Ask Stefan
+        publishedServiceName:
+          type: string
+          nullable: false
+          example: Circle Line
+        originText:
+          type: string
+          nullable: false
+        destinationText:
+          type: string
+          nullable: false
+
+    ContinuousMode:
+      description: >-
+        Types of modes that run at any time without a timetable. Provided by OJP.
+      type: string
+      x-extensible-enum:
+        - WALK
+        - DEMAND_RESPONSIVE
+        - REPLACEMENT_SERVICE
+
+    IndividualMode:
+      description: >-
+        Modes which an individual powers themselves (such as walk, cycle). Provided by OJP.
+      type: string
+      x-extensible-enum:
+        - WALK
+        - CYCLE
+        - TAXI
+        - SELF_DRIVE_CAR
+        - OTHERS_DRIVE_CAR
+        - MOTORCYCLE
+        - TRUCK
+        - SCOOTER
+        - RIDE_POOL_CAR
+        - CAR_SHARING
+        - CYCLE_SHARING
+        - SCOOTER_SHARING
+
+    TransferMode:
+      description: >-
+        Modes dedicated to perform transfers. Provided by OJP.
+      type: string
+      x-extensible-enum:
+        - WALK
+        - PARK_AND_RIDE
+        - BIKE_AND_RIDE
+        - CAR_HIRE
+        - BIKE_HIRE
+        - PROTECTED_CONNECTION
+        - GUARANTEED_CONNECTION
+        - REMAIN_IN_VEHICLE
+        - CHANGE_WITHIN_VEHICLE
+        - CHECK_IN
+        - CHECK_OUT
+
+    StopCallStatus:
+      type: object
+      additionalProperties: false
+      description: >-
+        Status properties for the vehicle call at this stop. Provided by OJP.
+      properties:
+        order:
+          description: >-
+            Sequence number of this stop in the service pattern of the journey.
+          type: integer
+          format: int32
+          minimum: 1
+        requestStop:
+          description: >-
+            The vehicle journey calls at this stop only on demand.
+          type: boolean
+          default: false
+        unplannedStop:
+          description: >-
+            This stop has not been planned by the planning department.
+          type: boolean
+          default: false
+        notServicedStop:
+          description: >-
+            The vehicle will not call at this stop despite earlier planning.
+          type: boolean
+          default: false
+        noBoardingAtStop:
+          description: >-
+            Boarding will not be allowed at this stop of this journey.
+          type: boolean
+          default: false
+        noAlightingAtStop:
+          description: >-
+            Alighting will not be allowed at this stop of this journey.
+          type: boolean
+          default: false
+
+    Board:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes the the situation at a stop or station at which the passenger boards a Leg
+        of a trip including time-related information. Provided by OJP.
+      required:
+        - stopPlaceRef
+        - stopPlaceName
+        - serviceDeparture
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        stopPlaceName:
+          type: string
+          nullable: false
+          example: Luzern
+        plannedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board/alight from the vehicle. According to
+            planned timetable.
+          type: string
+          example: 3
+        estimatedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board the vehicle. As to the latest realtime status.
+          type: string
+          example: 8
+        serviceDeparture:
+          $ref: '#/components/schemas/ServiceTime'
+        status:
+          $ref: '#/components/schemas/StopCallStatus'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceAttribute'
+
+    BoardSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal board specification.
+      required:
+        - stopPlaceRef
+        - serviceDeparture
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        serviceDeparture:
+          $ref: '#/components/schemas/ServiceTime'
+
+    Intermediate:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes the situation at a stop or station that lies between the Board and
+        Alight stop or station including time-related information. Provided by OJP.
+      required:
+        - stopPlaceRef
+        - stopPlaceName
+        - serviceArrival
+        - serviceDeparture
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        stopPlaceName:
+          type: string
+          nullable: false
+          example: Luzern
+        plannedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board/alight from the vehicle. According to
+            planned timetable.
+          type: string
+          example: 3
+        estimatedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board the vehicle. As to the latest realtime status.
+          type: string
+          example: 8
+        serviceArrival:
+          $ref: '#/components/schemas/ServiceTime'
+        serviceDeparture:
+          $ref: '#/components/schemas/ServiceTime'
+        status:
+          $ref: '#/components/schemas/StopCallStatus'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceAttribute'
+
+    IntermediateSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal intermediate specification.
+      required:
+        - stopPlaceRef
+        - serviceArrival
+        - serviceDeparture
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        serviceArrival:
+          $ref: '#/components/schemas/ServiceTime'
+        serviceDeparture:
+          $ref: '#/components/schemas/ServiceTime'
+
+    Alight:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes the situation at a stop or station at which the passenger alights from a Leg
+        of a trip including time-related information. Provided by OJP.
+      required:
+        - stopPlaceRef
+        - stopPlaceName
+        - serviceArrival
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        stopPlaceName:
+          type: string
+          nullable: false
+          example: Luzern
+        plannedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board/alight from the vehicle. According to
+            planned timetable.
+          type: string
+          example: 3
+        estimatedStopPointName:
+          description: >-
+            Name of the bay/quay/terminal where to board the vehicle. As to the latest realtime status.
+          type: string
+          example: 8
+        serviceArrival:
+          $ref: '#/components/schemas/ServiceTime'
+        status:
+          $ref: '#/components/schemas/StopCallStatus'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceAttribute'
+
+    AlightSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal alight specification
+      required:
+        - stopPlaceRef
+        - serviceArrival
+      properties:
+        stopPlaceRef:
+          $ref: '#/components/schemas/StopPlaceRef'
+        serviceArrival:
+          $ref: '#/components/schemas/ServiceTime'
+
+    ServiceTime:
+      type: object
+      additionalProperties: false
+      description: >-
+        Contains at least scheduled time, but can contain real time and estimated times. Provided by OJP.
+      required:
+        - timetabledTime
+      properties:
+        timetabledTime:
+          type: string
+          format: date-time
+          nullable: false
+        estimatedTime:
+          type: string
+          format: date-time
+        observedTime:
+          type: string
+          format: date-time
+
+    DatedJourney:
+      type: object
+      additionalProperties: false
+      description: >-
+        Vehicle journey that runs at a specific date. Provided by OJP.
+      required:
+        - vehicleNumbers
+        - carriers
+      properties:
+        operatingDayRef:
+          $ref: '#/components/schemas/OperationDayRef'
+        mode:
+          $ref: '#/components/schemas/Mode'
+        productCategory:
+          $ref: '#/components/schemas/ProductCategory'
+        publishedServiceName:
+          description: >-
+            Line name or service description as known to the public, f.e. '512', 'S8'
+            or 'Circle Line' or 'ICE 488'.
+          type: string
+          example: S1
+        vehicleNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/VehicleNumber'
+          minItems: 1
+        lineNumbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineNumber'
+        serviceStatus:
+          $ref: '#/components/schemas/ServiceStatus'
+        situationFullRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/SituationFullRef'
+        carriers:
+          type: array
+          items:
+            $ref: '#/components/schemas/NamedCompany'
+          minItems: 1
+
+    Mode:
+      type: object
+      additionalProperties: false
+      description: >-
+        A method of transportation such as bus, rail, etc. Provided by OJP.
+      required:
+        - ptMode
+      properties:
+        ptMode:
+          $ref: '#/components/schemas/PTMode'
+        name:
+          description: >-
+            Name of the mode
+          type: string
+          example: rail
+        shortName:
+          description: >-
+            Short name or acronym of the mode
+          type: string
+          example: S
+        description:
+          description: >-
+            Additional text that further describes the mode
+          type: string
+
+    PTMode:
+      description: >-
+        TAP-TSI/UIC contains a sensible subset of SIRI Transport Modes.
+      type: string
+      x-extensible-enum:
+        - HIGH_SPEED_TRAIN
+        - HISTORIC_TRAIN
+        - INTERCITY
+        - REGIONAL
+        - INTERREGIONAL
+        - URBAN
+        - TRAM
+        - UNDERGROUND
+        - NIGHT_TRAIN
+        - SHARED_TAXI
+        - MOTOR_RAIL
+        - MOUNTAIN_TRAIN
+        - PLANE
+        - COACH_GROUP
+        - SHIP
+        - BUS
+
+    ProductCategory:
+      type: object
+      additionalProperties: false
+      description: >-
+        Product category based on NeTEx/SIRI. A product category is a classification for vehicle journeys
+        to express some common properties of journeys for marketing and fare products. Provided by OJP.
+      required:
+        - name
+        - shortName
+        - productCategoryRef
+      properties:
+        name:
+          description: >-
+            Full name of this product category, e.g. 'TGV Lyria' in Switzerland and France.
+            UIC: Long name of Service Brand
+          type: string
+          nullable: false
+          example: TGV Lyria
+        shortName:
+          description: >-
+            Short name or acronym of the product category, likely to be published, e.g. 'TGV'
+            UIC: Abbreviation of Service Brand
+          type: string
+          nullable: false
+          example: TGV
+        productCategoryRef:
+          $ref: '#/components/schemas/ProductCategoryRef'
+
+    ServiceStatus:
+      type: object
+      additionalProperties: false
+      description: >-
+        Parameters which describe the current status of a dated vehicle journey.
+        Provided by OJP.
+      properties:
+        unplanned:
+          description: >-
+            Whether this trip is an additional one that has not been planned.
+          type: boolean
+          default: false
+        cancelled:
+          description: >-
+            Whether this trip is cancelled and will not be run.
+          type: boolean
+          default: false
+        deviation:
+          description: >-
+            Whether this trip deviates from the planned service pattern.
+          type: boolean
+          default: false
+        occupancy:
+          description: >-
+            Passenger load status on vehicle. If omitted, not known.
+            Equivalent to siri:OccupancyEnumeration which describes three values:
+            'full', 'seatingAvailable' and 'standingAvailable'.
+          type: string
+
+    Place:
+      type: object
+      additionalProperties: false
+      description: >-
+        A geographic place of any type which may be specified as the origin or destination of a trip. Provided by OJP.
+      required:
+        - id
+      properties:
+        id:
+          description: >-
+            id  defining the place. The code is provided as URN, relative URNs are allowed with base path urn:uic:stn '0850000'
+          type: string
+          nullable: false
+          example: urn:uic:stn:8500000
+        alternativeIds:
+          description: >-
+            For a place with ids in different reference systems, the alternative ids can be returned. 
+            The reference system is encoded in the string. E.g.: "urn:uic:std:80000", "x_swe:stn:10000", "ch:1:sloid:343434"
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+          example: Zürich HB
+        address:
+          $ref: '#/components/schemas/Address'
+        pointOfInterest:
+          $ref: '#/components/schemas/PointOfInterest'
+        stopPlace:
+          $ref: '#/components/schemas/StopPlace'
+        fareConnectionPoint:
+          $ref: '#/components/schemas/FareConnectionPoint'
+        geoPosition:
+          $ref: '#/components/schemas/GeoPosition'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    Address:
+      type: object
+      additionalProperties: false
+      description: >-
+        A descriptive data associated with a place that can be used to describe the unique geographical context of a
+        place for the purposes of identifying it. may be refined as either a road address, a postal address or both.
+        Provided by OJP.
+      properties:
+        code:
+          description: >-
+            id of the address
+          type: string
+          example: NL:1916200000022621
+        name:
+          description: >-
+            Name or description of address for use in passenger information.
+          type: string
+          example: Oude Trambaan 7, 2265CA Leidschendam, Nederland
+        countryName:
+          description: >-
+            Country of the address.
+          type: string
+          example: The Netherlands
+        countryCode:
+          $ref: '#/components/schemas/CountryCode'
+        postCode:
+          description: >-
+            Postal code of the address.
+          type: string
+          example: 2265CA
+        city:
+          description: >-
+            City name
+          type: string
+          example: Leidschendam
+        topographicPlaceName:
+          description: >-
+            TopographicPlace name of the address. If set it should at least contain the city name.
+          type: string
+          example: Leidschendam
+        street:
+          description: >-
+            Street name of the address.
+          type: string
+          example: Oude Trambaan
+        houseNumber:
+          description: >-
+            House number of the address. If none is given, either a crossing street can be given, or the whole street is meant.
+          type: string
+          example: 7
+
+    CountryCode:
+      type: string
+      description: >-
+        ISO country code (2 alpha), relative URNs with base urn:iso:std:iso:3166 are recommended
+      nullable: false
+      example: DE
+
+    PointOfInterest:
+      type: object
+      additionalProperties: false
+      description: >-
+        A type of place to or through which passengers may wish to navigate as part of
+        their journey and which is modelled in detail by journey planners. Provided by OJP.
+      required:
+        - code
+        - name
+      properties:
+        code:
+          description: >-
+            id of the Point of Interest.
+          type: string
+          nullable: false
+        name:
+          description: >-
+            Name or description of point of interest for use in passenger information.
+          type: string
+          nullable: false
+          example: Park Rozenrust
+
+    PointOfInterestCategory:
+      type: object
+      additionalProperties: false
+      description: >-
+        A categorization of points of interest in respect of the activities undertaken at them (defined by key-value-pairs). Provided by OJP.
+      properties:
+        osmTags:
+          description: >-
+            Open Street Map tag structure (key-value)
+          type: array
+          items:
+            $ref: '#/components/schemas/OsmTag'
+        pointOfInterestClassifications:
+          description: >-
+            Classification of the POI (when it is not from OSM). The codification of the
+            classification Id may include de codification source (for example
+            'IGN:[classificationCode]')
+          type: array
+          items:
+            type: string
+
+    OsmTag:
+      type: object
+      additionalProperties: false
+      description: >-
+        Structure of an Open Street Map tag. Provided by OJP.
+      required:
+        - tag
+        - value
+      properties:
+        tag:
+          description: >-
+            Name of Open Street Map tag (amenity, leisure, tourism, bike, ...)
+          type: string
+          nullable: false
+          example: name
+        value:
+          description: >-
+            Value for Open Street Map tag (charging_station, hostel, yes, ...)
+          type: string
+          nullable: false
+          example: Rozenrust
+
+    StopPlace:
+      type: object
+      additionalProperties: false
+      description: >-
+        A place extended by accessibility limitation properties and some attributes of the associated equipment,
+        comprising one or more places where vehicles may stop and where passengers may board or leave vehicles
+        or prepare their trip, and which will usually have one or more wellknown names. Provided by OJP.
+      required:
+        - ref
+        - name
+      properties:
+        ref:
+          $ref: '#/components/schemas/StopPlaceRef'
+        name:
+          description: >-
+            Name of this stop place for use in passenger information.
+          type: string
+          nullable: false
+          example: Zürich HB
+
+    PlaceRef:
+      type: object
+      additionalProperties: false
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+
+    StopPlaceRef:
+      description: >-
+        Reference to a Stop Place using URNs to define code.
+        For UIC see UIC MERITS/TAP-TSI station codes. Provided by OJP.
+      allOf:
+        - $ref: '#/components/schemas/PlaceRef'
+        - type: object
+          additionalProperties: false
+          required:
+            - stopPlaceRef
+          properties:
+            stopPlaceRef:
+              type: string
+              nullable: false
+              example: urn:uic:stn:8503000
+            name:
+              type: string
+
+    PointOfInterestRef:
+      description: >-
+        Reference to a Point of Interest. Provided by OJP.
+      allOf:
+        - $ref: '#/components/schemas/PlaceRef'
+        - type: object
+          additionalProperties: false
+          required:
+            - pointOfInterestRef
+          properties:
+            pointOfInterestRef:
+              type: string
+              nullable: false
+            name:
+              type: string
+
+    AddressRef:
+      description: >-
+        Reference to an Address.
+      allOf:
+        - $ref: '#/components/schemas/PlaceRef'
+        - type: object
+          additionalProperties: false
+          required:
+            - addressRef
+          properties:
+            addressRef:
+              type: string
+              nullable: false
+            name:
+              type: string
+
+    FareConnectionPointRef:
+      description: >-
+        Reference to a Fare Connection Point.
+      allOf:
+        - $ref: '#/components/schemas/PlaceRef'
+        - type: object
+          additionalProperties: false
+          required:
+            - fareConnectionPoint
+          properties:
+            fareConnectionPoint:
+              $ref: '#/components/schemas/FareConnectionPoint'
+            name:
+              type: string
+
+    GeoPositionRef:
+      description: >-
+        Reference to a GeoPosition consisting of latitude and longitude.
+      allOf:
+        - $ref: '#/components/schemas/PlaceRef'
+        - type: object
+          additionalProperties: false
+          required:
+            - latitude
+            - longitude
+          properties:
+            latitude:
+              $ref: '#/components/schemas/Latitude'
+            longitude:
+              $ref: '#/components/schemas/Longitude'
+
+    ProductCategoryRef:
+      type: string
+      description: >-
+        Reference to a product category. Product categories should be defined once and used
+        uniformly in all channels (e.g. NeTEx, SIRI, OJP). Provided by OJP.
+      example: urn:uic:sbc:76
+
+    OperationDayRef:
+      type: string
+      description: >-
+        Reference to an operating day. Provided by OJP.
+      example: OperatingDay:12345
+
+    JourneyRef:
+      type: string
+      description: >-
+        Reference to a journey. Provided by OJP.
+      example: ServiceJourney:1
+
+    SituationFullRef:
+      type: string
+      description: >-
+        Reference to situation message. Message details might be found in response
+        context or through other communication channels. Provided by OJP.
+
+    VehicleNumber:
+      type: string
+      description: >-
+        The vehicle number(s) of the vehicle that runs this timed leg. On some legs a vehicle can
+        have multiple vehicle numbers, e.g. if it is split into two trains at a intermediate stop.
+        E.g. the vehicle numbers of 'TGV 9218', 'TH 9340' or 'ICE 15'.
+        For backwards compatibility with Hermes/Hosa the length of the string must be restricted
+        to 5 characters. If's longer, it is not possible to use the H2O converter.
+      example: 9218, 9340, 15
+
+    LineNumber:
+      type: string
+      description: >-
+        Especially on regional traffic, a vehicle is defined by a line number.
+        E.g. the line numbers of 'S 52' or 'B 19'.
+      example: 52, 19
+
+    OfferSearchCriteria:
+      type: object
+      additionalProperties: false
+      properties:
+        requestedOfferParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferPartType'
+        productTags:
+          type: array
+          items:
+            type: string
+        flexibilities:
+          description: >-
+            Defines the flexibility levels desired of the fares returned.
+            This refers to the after sales flexibility levels as defined in IRS-90918-10
+          type: array
+          items:
+            $ref: '#/components/schemas/Flexibility'
+        travelClasses:
+          description: >-
+            The classes returned might be different from the requested classes.
+          type: array
+          items:
+            $ref: '#/components/schemas/TravelClass'
+        serviceClassTypes:
+          description: >-
+            The classes returned might be different from the requested classes.
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceClassType'
+          maxItems: 4
+        offerMode:
+          $ref: '#/components/schemas/OfferMode'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        nutsCodes:
+          description: >-
+            Nomenclature des units territoriales statistiques COMMISSION REGULATION (EU) No 31/2011
+          type: array
+          items:
+            type: string
+        place:
+          $ref: '#/components/schemas/PlaceRef'
+
+    OfferPartType:
+      description: >-
+        Allows to request offerparts of a certain type.
+        To support H/H use ['RESERVATION', 'ANCILLARY'].
+        Default is to get search for offers of all types.
+      type: string
+      enum:
+        - ADMISSION
+        - RESERVATION
+        - ANCILLARY
+        - FARE_ADMISSION
+        - FARE_RESERVATION
+        - FARE_ANCILLARY
+        - ALL
+
+    OfferCollectionRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Defines the parameters needed to request an offer. Either a tripSearchCriteria, a list of trip specifications, or a list of tripIds can be passed in to request offers.
+        
+        If you are searching for fares you pass in the complete trip and the use the requestedSections attribute to define which part(s) you need fares (including virtual border points).
+        
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+        - anonymousPassengerSpecifications
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+        tripSpecifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripSpecification'
+        tripSearchCriteria:
+          $ref: '#/components/schemas/TripSearchCriteria'
+        tripIds:
+          type: array
+          items:
+            type: string
+        requestedSections:
+          type: array
+          items:
+            $ref: '#/components/schemas/Section'
+        offerSearchCriteria:
+          $ref: '#/components/schemas/OfferSearchCriteria'
+        anonymousPassengerSpecifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnonymousPassengerSpecification'
+          minItems: 1
+        corporateCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorporateCode'
+        promotionCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionCode'
+        requestedFulfillmentOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentOption'
+        embed:
+          description: >-
+            Influences whether referenced resources are returned in full or as references only. Proposed default ALL
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferCollectionResponseContent'
+
+    ReturnSearchParameters:
+      type: object
+      additionalProperties: false
+      description: >-
+        This property can be used in case a return trip is being requested.
+        This will allow to benefit from return-specific fares or product
+        
+      properties:
+        inwardReturnDate:
+          description: >-
+            Needs to be provided when creating the collection of outward travels so that the
+            provider knows when a return travel can be expected and propose appropriate
+            product and fares.
+          type: string
+          format: date-time
+        outwardOfferIds:
+          description: >-
+            Needs to be provided when creating the collection of inward travels so that the provider
+            can relate the inward travels to the outward travels context.
+          type: array
+          items:
+            type: string
+        outwardOfferTag:
+          description: >-
+            Needs to be provided when creating the collection of inward travels so that the provider
+            knows what the outward offer is and and propose compatible offers only if desired or mandatory.
+          type: string
+
+    OfferCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        offers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Offer'
+        anonymousPassengerSpecifications:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnonymousPassengerSpecification'
+        trips:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trip'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    Offer:
+      type: object
+      additionalProperties: false
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+        - offerId
+        - passengerRefs
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+        offerId:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the offer.
+          type: string
+        offerSummary:
+          $ref: '#/components/schemas/OfferSummary'
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        admissionOfferParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdmissionOfferPart'
+        reservationOfferParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReservationOfferPart'
+        ancillaryOfferParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AncillaryOfferPart'
+        fees:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fee'
+        fares:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fare'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    RequestedInformation:
+      type: string
+      description: >-
+        Boolean-expression indicating the data that must be set in the data
+        model in order to proceed to next step of the process.
+
+    OfferSummary:
+      type: object
+      additionalProperties: false
+      description: >-
+        The offer summary indicates the most relevant service class, level, flexibility or accommodation
+        that describe this offer, but this does not imply that these values exactly apply to all parts of
+        the offer.
+        Let's consider, as a simplified example, a trip composed of two legs, one with both 1st and
+        2nd class, and one with only 2nd.
+        On this trip, the railway is expected to propose one offer with overallServiceClass FIRST composed
+        of one admission in 1st class on the first legs and one admission in 2nd class on the second one,
+        plus a second offer with overallServiceClass SECOND composed of two second class admissions.
+        Likewise for all 'overall' attributes. The purpose of these attributes is to convey to the client
+        system the service class, level, flexibility and accommodation that best represent this offer so to
+        facilitate presentation to the final user.
+      required:
+        - minimalPrice
+        - overallServiceClass
+        - overallFlexibility
+      properties:
+        minimalPrice:
+          $ref: '#/components/schemas/Price'
+        overallServiceClass:
+          $ref: '#/components/schemas/ServiceClass'
+        overallTravelClass:
+          $ref: '#/components/schemas/TravelClass'
+        overallAccommodationType:
+          $ref: '#/components/schemas/AccommodationType'
+        overallAccommodationSubType:
+          $ref: '#/components/schemas/AccommodationSubType'
+        overallFlexibility:
+          $ref: '#/components/schemas/Flexibility'
+
+    AbstractOfferPart:
+      type: object
+      additionalProperties: false
+      description: >-
+        Generic offer object that contains all common information about an offer.
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+        - id
+        - price
+        - offerMode
+        - passengerRefs
+        - refundable
+        - exchangeable
+        - validFrom
+        - products
+        - availableFulfillmentOptions
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the Offer.
+          type: string
+        price:
+          $ref: '#/components/schemas/Price'
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        priceGuaranteedUntil:
+          description: >-
+            Indicates until when the price for the given offer is guaranteed.
+          type: string
+          format: date-time
+        offerMode:
+          $ref: '#/components/schemas/OfferMode'
+        isReusable:
+          description: >-
+            Indicates whether the offerId can be used in more than one booking.
+          type: boolean
+          default: false
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        numericAvailability:
+          type: integer
+          format: int32
+        refundable:
+          $ref: '#/components/schemas/RefundType'
+        exchangeable:
+          $ref: '#/components/schemas/ExchangeableType'
+        afterSalesConditions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AfterSaleCondition'
+        validFrom:
+          type: string
+          format: date-time
+          nullable: false
+        validUntil:
+          type: string
+          format: date-time
+        tripTags:
+          description: >-
+            List of tags (and their type) that allow identifying sets of compatible offers when trying to combine multiple offers covering one single trip.
+            At least one (not all) tripTags must be in common to allow combination
+            If no tag is provided, there is no trip constraint on this specific offer.
+            
+          type: array
+          items:
+            type: string
+        returnTags:
+          description: >-
+            List of tags (and their type) that allow identifying sets of compatible offers when booking a return trip
+            involving return-specific fares. All returnTags must be present in the counterpart offer to allow combination
+            If no tag is provided, there is no return constraint on this specific offer.
+          type: array
+          items:
+            type: string
+        offerTag:
+          $ref: '#/components/schemas/OfferTag'
+        requestedInformation:
+          $ref: '#/components/schemas/RequestedInformation'
+        products:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductLegAssociation'
+          minItems: 1
+        availableFulfillmentOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentOption'
+          minItems: 1
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        appliedPromotionCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionCode'
+        appliedCorporateCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorporateCode'
+        appliedReductions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReductionCard'
+        regionalValiditySummary:
+          $ref: '#/components/schemas/RegionalValiditySummary'
+
+    OfferTag:
+      type: object
+      additionalProperties: false
+      description: >-
+        The offerTag can/must (depending on the mandatory flag) be used in some cases to restrict the
+        set of offers returned in a subsequent and related offer search to only compatible ones.
+        Note the offerTag does not need to be unique.
+      properties:
+        id:
+          type: string
+        isMandatory:
+          type: boolean
+          default: false
+
+    BookedOffer:
+      type: object
+      additionalProperties: false
+      description: >-
+        The attribute 'offerSummary' is meaningful at trip-offer-collection response time only.
+      required:
+        - offerId
+      properties:
+        offerId:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the booked offer.
+          type: string
+        admissions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Admission'
+        reservations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Reservation'
+        ancillaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/Ancillary'
+        fees:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fee'
+        fares:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fare'
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        appliedThroughTicketTags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThroughTicketTag'
+
+    TravelClass:
+      description: >-
+        Traditional first and second class.
+      type: string
+      x-extensible-enum:
+        - FIRST
+        - SECOND
+        - ANY_CLASS
+
+    Flexibility:
+      type: string
+      x-extensible-enum:
+        - FULL_FLEXIBLE
+        - SEMI_FLEXIBLE
+        - NON_FLEXIBLE
+
+    AbstractBookingPart:
+      type: object
+      additionalProperties: false
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+        - id
+        - summary
+        - price
+        - status
+        - passengerIds
+        - validFrom
+        - refundable
+        - exchangeable
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+        id:
+          type: string
+          nullable: false
+        summary:
+          type: string
+          nullable: false
+        price:
+          $ref: '#/components/schemas/Price'
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        products:
+          description: >-
+            In offer mode, in almost all cases exactly one product is referenced. Only on some French
+            trips consisting of a TGV and a TER two products need to be used.
+            In fare mode, no product exists as first needs to created from the different fares.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductLegAssociation'
+        status:
+          $ref: '#/components/schemas/BookingPartStatus'
+        offerMode:
+          $ref: '#/components/schemas/OfferMode'
+        allocatorBookingRef:
+          description: >-
+            The booking reference of the booking the offer part is in on the provider side.
+          type: string
+        providerBookingRef:
+          description: >-
+            The booking reference of the order the offer part is in on the final provider side = the provider actually hosting or allocating  the product.
+          type: string
+        passengerIds:
+          description: >-
+            Id of the passenger
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        availableFulfillmentOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentOption'
+        validFrom:
+          description: >-
+            Validity of offer towards passenger
+          type: string
+          format: date-time
+          nullable: false
+        validUntil:
+          description: >-
+            Validity of offer towards passenger
+          type: string
+          format: date-time
+        refundable:
+          $ref: '#/components/schemas/RefundType'
+        exchangeable:
+          $ref: '#/components/schemas/ExchangeableType'
+        afterSaleConditions:
+          description: >-
+            Fine grained specification of the after sale condition of the booking.
+          type: array
+          items:
+            $ref: '#/components/schemas/AfterSaleCondition'
+        appliedCorporateCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorporateCode'
+        appliedPromotionCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionCode'
+        appliedReductions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+
+    RefundType:
+      type: string
+      enum:
+        - YES
+        - NO
+        - WITH_CONDITION
+
+    ExchangeableType:
+      description: >-
+        If set to YES the offerpart is exchangeable without a fee before the day of departure. 
+        NO when not exchangeable or exchangeable with 100% fee, WITH_CONDITIONS in all other cases.
+      type: string
+      enum:
+        - YES
+        - NO
+        - WITH_CONDITION
+
+    ProductLegAssociation:
+      type: object
+      additionalProperties: false
+      description: >-
+        In offer mode, in almost all cases exactly one product is referenced. Only on some French
+        trips consisting of a TGV and a TER two products need to be used.
+        In fare mode, no product exists as first needs to created from the different fares.
+      required:
+        - productId
+      properties:
+        productId:
+          type: string
+          nullable: false
+        legIds:
+          description: >-
+             indices of the legs in the trip given by the provider of the offer
+          type: array
+          items:
+            type: string
+
+    AfterSaleCondition:
+      type: object
+      additionalProperties: false
+      description: >-
+        After sale amounts for a given offer.
+      properties:
+        condition:
+          $ref: '#/components/schemas/AfterSaleConditionType'
+        validFrom:
+          type: string
+          format: date-time
+        validUntil:
+          type: string
+          format: date-time
+        afterSaleFee:
+          $ref: '#/components/schemas/Price'
+
+    AfterSaleConditionType:
+      type: string
+      x-extensible-enum:
+        - PLACE_CHANGE
+        - EXCHANGE
+        - REFUND
+
+    ProductCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        products:
+          description: >-
+            The list of all products available to the caller.
+          type: array
+          items:
+            $ref: '#/components/schemas/Product'
+
+    ProductResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        product:
+          $ref: '#/components/schemas/Product'
+
+    Product:
+      type: object
+      additionalProperties: false
+      description: >-
+        Structured description of the product, its name, comfort and sales / after-sales conditions
+      required:
+        - id
+        - code
+        - owner
+      properties:
+        id:
+          description: >-
+            id of the product
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the product.
+          type: string
+        code:
+          description: >-
+            The product code expressed in the provider system (could be a
+            mapping from an even lower-level provider).
+          type: string
+          nullable: false
+          example: PT00AD
+        description:
+          description: >-
+            Textual description of the product.
+          type: string
+          example: Loisir Non-flex Adult Fare
+        owner:
+          type: string
+          nullable: false
+        conditions:
+          description: >-
+            Structured description of the sales or after-sales conditions.
+          type: array
+          items:
+            $ref: '#/components/schemas/Condition'
+        serviceClass:
+          $ref: '#/components/schemas/ServiceClass'
+        travelClass:
+          $ref: '#/components/schemas/TravelClass'
+        isTrainBound:
+          type: boolean
+          default: false
+        isReturnProduct:
+          type: boolean
+          default: false
+        fulfillmentOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentOption'
+        serviceConstraintText:
+          type: string
+        carrierConstraintText:
+          type: string
+        tariff:
+          description: >-
+            Mapping to Tariff 42 of IRS-90918-3 (Hermes/Hosa). Helps the H2O converter in mapping
+            offers to a requested tariff. See legacyReservationParameter.tariff in OSDM offline.
+          type: string
+        combinationTags:
+          type: array
+          items:
+            $ref: '#/components/schemas/CombinationTag'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    CombinationTag:
+      type: object
+      additionalProperties: false
+      description: >-
+        Tag to indicate that some products from a provider can be sold only when in conjunction
+        with product(s) from another provider using the same tag. At least one, not all,
+        combinationTags must be in common to allow combination. No combinationTags indicate
+        that there are no combination constraints on the product.
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          nullable: false
+        needsToBeCombined:
+          description: >-
+            If false it means that this product can be sold also when not in conjunction with
+            a product with the same tag. This is needed to propose specific products from one
+            provider that depend on public ones of another.
+          type: boolean
+          default: false
+
+    FulfillmentMediaType:
+      description: >-
+        Fulfillment types. RCT2, RCCST and UIC_PDF are official UIC standards.
+      type: string
+      x-extensible-enum:
+        - ALLOCATOR_APP
+        - PDF_A4
+        - PKPASS
+        - RCCST
+        - RCT2
+        - UIC_PDF
+        - TICKETLESS
+
+    Admission:
+      description: >-
+        An admission represents a travel right, or the entitlement to travel onboard a train between
+        the given origin and destination, following the given route. It does not include a seat reservation.
+      allOf:
+        - $ref: '#/components/schemas/AbstractBookingPart'
+        - type: object
+          additionalProperties: false
+          required:
+            - isReservationRequired
+          properties:
+            isReservationRequired:
+              type: boolean
+              nullable: false
+              default: false
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+            reservationRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+            ancillaryRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+            regulatoryConditions:
+              type: array
+              items:
+                $ref: '#/components/schemas/RegulatoryCondition'
+
+    AdmissionOfferPart:
+      description: >-
+        An admission represents a travel right, or the entitlement to travel onboard a train between
+        the given origin and destination, following the given route. It does not include a seat reservation.
+      allOf:
+        - $ref: '#/components/schemas/AbstractOfferPart'
+        - type: object
+          additionalProperties: false
+          properties:
+            isReservationRequired:
+              type: boolean
+            reservations:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReservationRelation'
+            ancillaries:
+              type: array
+              items:
+                $ref: '#/components/schemas/AncillaryRelation'
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/OfferPartReference'
+            regulatoryConditions:
+              type: array
+              items:
+                $ref: '#/components/schemas/RegulatoryCondition'
+            includedReservations:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReservationOfferPart'
+            throughTicketTags:
+              type: array
+              items:
+                $ref: '#/components/schemas/ThroughTicketTag'
+
+    AncillaryRelation:
+      type: object
+      additionalProperties: false
+      required:
+        - minGroupItemsToBeBooked
+        - ancillaryGroup
+      properties:
+        minGroupItemsToBeBooked:
+          type: integer
+          format: int32
+          nullable: false
+        maxGroupItemsToBeBooked:
+          type: integer
+          format: int32
+        ancillaryGroup:
+          $ref: '#/components/schemas/AncillaryGroup'
+
+    Reservation:
+      description: >-
+        Reservation includes the reference to the in the initial offer.
+        The offer needs to be updated with the selected places before the confirmation
+        which creates the reservation details including the reserved places.
+      allOf:
+        - $ref: '#/components/schemas/AbstractBookingPart'
+        - type: object
+          additionalProperties: false
+          properties:
+            placeSelection:
+              $ref: '#/components/schemas/PlaceSelection'
+            placeAllocation:
+              $ref: '#/components/schemas/PlaceAllocation'
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+            ancillaryRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+
+    ReservationOfferPart:
+      description: >-
+        Reservation includes the reference to the in the initial offer.
+        The offer needs to be updated with the selected places before the confirmation
+        which creates the reservation details including the reserved places.
+      allOf:
+        - $ref: '#/components/schemas/AbstractOfferPart'
+        - type: object
+          additionalProperties: false
+          properties:
+            ancillaries:
+              type: array
+              items:
+                $ref: '#/components/schemas/AncillaryRelation'
+            availablePlaces:
+              type: array
+              items:
+                $ref: '#/components/schemas/AvailablePlace'
+            availablePlacePreferences:
+              type: array
+              items:
+                $ref: '#/components/schemas/AvailablePlacePreferences'
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/OfferPartReference'
+
+    Ancillary:
+      allOf:
+        - $ref: '#/components/schemas/AbstractBookingPart'
+        - type: object
+          additionalProperties: false
+          required:
+            - type
+          properties:
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/BookingPartReference'
+            type:
+              $ref: '#/components/schemas/AncillaryType'
+
+    AncillaryOfferPart:
+      allOf:
+        - $ref: '#/components/schemas/AbstractOfferPart'
+        - type: object
+          additionalProperties: false
+          required:
+            - type
+          properties:
+            feeRefs:
+              type: array
+              items:
+                $ref: '#/components/schemas/OfferPartReference'
+            category:
+              description: >-
+                Categorization of the ancillary such as "Meal" or "Gift".
+              type: string
+            type:
+              $ref: '#/components/schemas/AncillaryType'
+
+    Fee:
+      type: object
+      additionalProperties: false
+      description: >-
+        Fees are used to represent additional costs for services or products.   In contrast to other offer parts in OSDM, the customer is not free whether to choose a fee or not: fees are generated and applied to other services or products by the provider system.
+      required:
+        - id
+        - price
+      properties:
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the fee.
+          type: string
+        price:
+          $ref: '#/components/schemas/Price'
+        applicability:
+          $ref: '#/components/schemas/ApplicabilityType'
+        providerBookingReference:
+          description: >-
+            The booking reference of the booking the offer part is in on the provider side.
+          type: string
+        refundable:
+          $ref: '#/components/schemas/RefundType'
+        conditions:
+          description: >-
+            Structured description of the sales or after-sales conditions.
+          type: array
+          items:
+            $ref: '#/components/schemas/Condition'
+        productCode:
+          description: >-
+            The product code expressed in the provider system (could be a
+            mapping from an even lower-level provider).
+          type: string
+
+    ApplicabilityType:
+      type: string
+      x-extensible-enum:
+        - BOOKING
+        - TRIP
+        - OFFERPART
+
+    PromotionCode:
+      type: object
+      additionalProperties: false
+      description: >-
+        The promotion code is a token that reduces the price at POST booking time OR
+        Token that reduces the price at POST trip-offer-collection time OR
+        Token to receive offers that are not available without it.
+      required:
+        - code
+      properties:
+        code:
+          description: >-
+            The code issued by the issuer
+          type: string
+          nullable: false
+          example: SPRING_DISCOUNT
+        issuer:
+          description: >-
+            The party that issues the promotion code, in case of a railway it's its RICS code
+          type: string
+
+    BookingPartReference:
+      type: object
+      additionalProperties: false
+      description: >-
+        References all the offer part elements in an uniform format.
+        In its part, an OfferPartReference can refer to reservation, admission, ancillary or fee.
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the offer part reference.
+          type: string
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    CorporateCode:
+      type: object
+      additionalProperties: false
+      description: >-
+        The corporate code is a token that reduces the price at POST trip-offer-collection time OR
+        trip-offer-request or Token to receive offers that are not available without it, associated with an
+        agreement between allocator/carrier and a corporate client.
+      required:
+        - code
+        - issuer
+      properties:
+        code:
+          description: >-
+            The corporate code issued by the referenced company.
+          type: string
+          nullable: false
+          example: 123-232
+        beneficiary:
+          description: >-
+            The name of the party that benefits from the corporate code, intended to be presented to the end user.
+          type: string
+          example: Siemens
+        issuer:
+          $ref: '#/components/schemas/CompanyRef'
+
+    OfferPartReference:
+      type: object
+      additionalProperties: false
+      description: >-
+        References all the offer part elements in an uniform format.
+        In its part, an OfferPartReference can refer to reservation, admission, ancillary or fee.
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the offer part reference.
+          type: string
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    BookingRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - offers
+        - passengerSpecifications
+        - externalRef
+      properties:
+        offers:
+          description: >-
+            The list of offers that need to be provisionally booked, with possibly the reservations and ancillaries associated that should be booked as well.
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferSelection'
+          minItems: 1
+        passengerSpecifications:
+          description: >-
+            If needed (cf requiredInformation) or desired, this array allows providing the required details on some or all passengers
+          type: array
+          items:
+            $ref: '#/components/schemas/PassengerSpecification'
+          minItems: 1
+        purchaser:
+          $ref: '#/components/schemas/PurchaserSpecification'
+        promotionCodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionCode'
+        embed:
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+          type: array
+          items:
+            $ref: '#/components/schemas/BookingResponseContent'
+        externalRef:
+          type: string
+          nullable: false
+
+    OfferSelection:
+      type: object
+      additionalProperties: false
+      description: >-
+        The Ids of the offers to be booked need to be passed in.
+      required:
+        - offerId
+        - passengerRefs
+      properties:
+        offerId:
+          description: >-
+            id of the selected offer or exchangeOffer
+          type: string
+          nullable: false
+        optionalReservationSelections:
+          description: >-
+            Mandatory reservations are booked when the booking is being booked.
+          type: array
+          items:
+            $ref: '#/components/schemas/ReservationSelection'
+        optionalAncillarySelections:
+          type: array
+          items:
+            $ref: '#/components/schemas/AncillarySelection'
+        placeSelections:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceSelection'
+        afterSaleByDistributorOnly:
+          description: >-
+            in case the distributor has proposed this offer in conjunction with an offer of another provider constrained
+            by a combinationTag, this flag must be set to true to indicate to the provider that after-sale must be done
+            on the totality of the distributor's booking. Only after-sale requests triggered by the distributor can be
+            safely processed on this offer. When the flag is not set, standard provider logic applies.
+          type: boolean
+          default: false
+        appliedRegulatoryCondition:
+          $ref: '#/components/schemas/RegulatoryCondition'
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        throughTicketTags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThroughTicketTag'
+
+    AncillarySelection:
+      type: object
+      additionalProperties: false
+      description: >-
+        Is some cases one out of a set of ancillary offerparts must be booked.
+      required:
+        - ancillaryId
+        - passengerRefs
+      properties:
+        ancillaryId:
+          type: string
+          nullable: false
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+
+    BookingResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        booking:
+          $ref: '#/components/schemas/Booking'
+
+    Booking:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - passengers
+      properties:
+        id:
+          type: string
+          nullable: false
+        externalRef:
+          description: >-
+            The unique booking reference in the provider system. Usually refers to an order number or PNR.
+          type: string
+        summary:
+          description: >-
+            A human-readable description of the booking.
+          type: string
+          example: Booking 2345 for Clemens Gantert
+        passengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+          minItems: 1
+        purchaser:
+          $ref: '#/components/schemas/Purchaser'
+        provisionalPrice:
+          $ref: '#/components/schemas/Price'
+        confirmedPrice:
+          $ref: '#/components/schemas/Price'
+        bookedOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookedOffer'
+        trips:
+          description: >-
+            This trip will be included in the offer if the offer is part of the booking.
+          type: array
+          items:
+            $ref: '#/components/schemas/Trip'
+        requestedInformation:
+          $ref: '#/components/schemas/RequestedInformation'
+        ticketTimeLimit:
+          type: string
+          format: date-time
+        fulfillmentType:
+          $ref: '#/components/schemas/FulfillmentType'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        paymentMethods:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentMethod'
+        refundOffers:
+          description: >-
+            Refund offers are created with the details of the to-be-confirmed refund operation.
+            One refund offer can then be confirmed, which turns it into a refund.
+          type: array
+          items:
+            $ref: '#/components/schemas/RefundOffer'
+        releaseOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReleaseOffer'
+        cancelFulfillmentsOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/CancelFulfillmentsOffer'
+        exchangeOperations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExchangeOperation'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    BookingPartStatus:
+      type: string
+      enum:
+        - PREBOOKED
+        - ON_HOLD
+        - CONFIRMED
+        - FULFILLED
+        - CANCELLED
+        - RELEASED
+        - REFUNDED
+        - EXCHANGE_ONGOING
+        - ERROR
+
+    FulfillmentType:
+      type: string
+      x-extensible-enum:
+        - ETICKET
+        - CIT_PAPER
+        - PASS_CHIP
+        - PASS_REFERENCE
+
+    BookingPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Allows setting the required fulfillment type, e.g. value paper
+        or e-ticket and preferred fulfillment media.
+        The latter is optional and relevant in some cases only.
+      properties:
+        placeSelections:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceSelection'
+        requestedFulfillmentType:
+          $ref: '#/components/schemas/FulfillmentType'
+        preferredFulfillmentMedia:
+          $ref: '#/components/schemas/FulfillmentMediaType'
+        usedPaymentMethods:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentMethod'
+        exchangeOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferSelection'
+
+    FulfillmentOption:
+      type: object
+      additionalProperties: false
+      description: >-
+        CIT paper implies printing on value paper which is stock controlled.
+      required:
+        - type
+        - media
+      properties:
+        type:
+          $ref: '#/components/schemas/FulfillmentType'
+        media:
+          $ref: '#/components/schemas/FulfillmentMediaType'
+
+    FulfillmentPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Changes the fulfillment to status FULFILLED.
+      properties:
+        fulfillmentUpdates:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentId'
+
+    FulfillmentId:
+      type: string
+      nullable: false
+
+    FulfillmentCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+
+    FulfillmentResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        fulfillment:
+          $ref: '#/components/schemas/Fulfillment'
+
+    Fulfillment:
+      type: object
+      additionalProperties: false
+      description: >-
+        A fulfillment is a document (or part of a document in allocator mode) that
+        - allows the passenger to prove its travel right
+        - provides easier access to trains and stations
+        - allows an exchange for other services (voucher)
+        A fulfillment refers to services of one or multiple offer parts or a fare (allocator mode).
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the fulfillment.
+          type: string
+        status:
+          $ref: '#/components/schemas/FulfillmentStatus'
+        controlNumber:
+          description: >-
+            Ticket Control Number.
+          type: string
+        offerParts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferPartReference'
+        availableUsage:
+          $ref: '#/components/schemas/FulfillmentUsage'
+        fulfillmentDocuments:
+          description: >-
+            Final document created for fulfillment.
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentDocument'
+        fulfillmentParts:
+          description: >-
+            Fulfillment items to be integrated into tickets (allocator mode).
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentPart'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    FulfillmentPartStatus:
+      description: >-
+        Individual fulfillments of a multi journey booking need an separate patch to create the usable fulfillment in status FULFILLED before they are in an intermediate state AVAILABLE where they don't provide a document for travel. Fulfillments can be ON_HOLD in case they are booked but not yet available (e.g. a booking providing two journeys per week) or passed in case the fulfillment was not patched for usage within the required time.
+      type: string
+      enum:
+        - AVAILABLE
+        - ON_HOLD
+        - CONFIRMED
+        - FULFILLED
+        - CHECKEDIN
+        - CANCELLED
+        - RELEASED
+        - REFUNDED
+        - EXPIRED
+
+    FulfillmentStatus:
+      description: >-
+        Individual fulfillments of a multi journey booking need an separate patch to create the usable fulfillment in status FULFILLED before they are in an intermediate state AVAILABLE where they don't provide a document for travel. Fulfillments can be ON_HOLD in case they are booked but not yet available (e.g. a booking providing two journeys per week) or passed in case the fulfillment was not patched for usage within the required time.
+      type: string
+      enum:
+        - AVAILABLE
+        - ON_HOLD
+        - CONFIRMED
+        - FULFILLED
+        - CHECKEDIN
+        - CANCELLED
+        - RELEASED
+        - REFUNDED
+        - EXPIRED
+
+    FulfillmentDocument:
+      type: object
+      additionalProperties: false
+      description: >-
+        Document created for fulfillment. Either downloadLink + downloadExpiry or content + format must
+        be provided.
+      required:
+        - medium
+        - type
+        - format
+      properties:
+        medium:
+          $ref: '#/components/schemas/FulfillmentMediaType'
+        type:
+          $ref: '#/components/schemas/FulfillmentDocumentType'
+        downloadLink:
+          type: string
+          format: uri
+        downloadExpiry:
+          description: >-
+            Expiration time of the download link, the document will not be available at the given URI
+            after this time.
+          type: string
+          format: date-time
+        content:
+          description: >-
+            base64 encoded binary of the actual fulfillment document
+          type: string
+          format: byte
+        format:
+          description: >-
+            Physical format of the document provided in the content field in Mime-Type format, e.g.
+            application/pdf, image/jpeg, etc. Must be filled if the 'content' field is present.
+          type: string
+          nullable: false
+          example: application/pdf
+
+    FulfillmentDocumentType:
+      type: string
+      x-extensible-enum:
+        - BOOKING_RECEIPT
+        - TICKET
+        - BOARDING_PASS
+        - INFORMATION
+        - VOUCHER
+
+    FulfillmentPart:
+      type: object
+      additionalProperties: false
+      description: >-
+        Fulfillment items to be integrated in to tickets,
+        e.g. visual security elements, additional bar codes, control keys.
+      required:
+        - status
+      properties:
+        fulfillmentMedia:
+          description: >-
+            list of fulfillment media where this item applies
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentMediaType'
+        passengerReference:
+          description: >-
+            reference to a passenger
+          type: string
+        controlId:
+          type: string
+        securityFeatures:
+          description: >-
+            'visual elements, bar codes'
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentItemSecurityFeature'
+        securityFeatureLinks:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentItemSecurityFeatureLinks'
+        isMandatory:
+          description: >-
+            The use of the provided features is mandatory.
+          type: boolean
+          default: false
+        securePaperOnly:
+          description: >-
+            The security feature must be used on secure paper.
+          type: boolean
+          default: false
+        status:
+          $ref: '#/components/schemas/FulfillmentPartStatus'
+
+    FulfillmentItemSecurityFeature:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          $ref: '#/components/schemas/SecurityFeatureType'
+        data:
+          description: >-
+            base 64 encoded data
+          type: string
+          format: byte
+
+    FulfillmentItemSecurityFeatureLinks:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          $ref: '#/components/schemas/SecurityFeatureType'
+        uri:
+          description: >-
+            link to download the security feature
+          type: string
+          format: uri
+
+    FulfillmentUsage:
+      type: object
+      additionalProperties: false
+      description: >-
+        In case of multi-journey products describe parameters to be used to change the a fulfillment in status AVAILABLE to FULFILLED so it can be used by the passenger.
+      required:
+        - fromPlaceRequired
+        - maxAvailableZones
+      properties:
+        fromPlaceRequired:
+          type: boolean
+          nullable: false
+          default: false
+        travelDates:
+          description: >-
+            Travel dates that can be selected. Note: date only is used to cover properly the case of passes including
+            multiple time zones.
+          type: array
+          items:
+            type: string
+        travelValidityRanges:
+          type: array
+          items:
+            $ref: '#/components/schemas/TravelValidityRange'
+        maxAvailableZones:
+          description: >-
+            upper limit to the number of selected zones
+          type: integer
+          format: int32
+          nullable: false
+        availableZones:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZoneDefinition'
+
+    SecurityFeatureType:
+      type: object
+      additionalProperties: false
+      description: >-
+        Defines type and format of the security feature.
+      properties:
+        type:
+          $ref: '#/components/schemas/SecurityElementType'
+        format:
+          $ref: '#/components/schemas/SecurityElementFormat'
+
+    SecurityElementType:
+      type: string
+      enum:
+        - VISUAL_ELEMENT
+        - BAR_CODE
+
+    TravelValidityRange:
+      type: object
+      additionalProperties: false
+      description: >-
+        Range for the start of validity to be used in a patch for available fulfillments (e.g. a 1 hour ticket not
+        available during  peak hours in the morning and afternoon).
+      required:
+        - from
+        - until
+      properties:
+        from:
+          type: string
+          format: date
+          nullable: false
+        until:
+          type: string
+          format: date
+          nullable: false
+
+    SecurityElementFormat:
+      type: string
+      enum:
+        - PNG
+        - GIF
+        - SVG
+
+    RefundOfferCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        refundOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/RefundOffer'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    RefundOffer:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          description: >-
+            id of the refund offer
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the refund offer.
+          type: string
+          example: Refund Offer for Paris-Barcelona Andre Dupont 2022-07-23
+        validUntil:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/RefundStatus'
+        reimbursementStatus:
+          $ref: '#/components/schemas/ReimbursementStatus'
+        reimbursementDateTime:
+          type: string
+          format: date-time
+        appliedOverruleCode:
+          $ref: '#/components/schemas/OverruleCode'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+        refundFee:
+          $ref: '#/components/schemas/Price'
+        refundableAmount:
+          $ref: '#/components/schemas/Price'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ReimbursementStatus:
+      type: string
+      enum:
+        - IMMEDIATE
+        - DELAYED
+      default: IMMEDIATE
+
+    RefundOfferRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Request for a refund offer.
+        Fulfillments can be provided in case the booking contains multiple individual fulfillments.
+      required:
+        - fulfillmentIds
+      properties:
+        fulfillmentIds:
+          description: >-
+            id of the fulfillment to refund
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        overruleCode:
+          $ref: '#/components/schemas/OverruleCode'
+        refundDate:
+          description: >-
+            Indicates for passes the date taken as reference to compute possible partial refund. It is also the date taken
+            as reference to invalidate the pass partially refunded.
+          type: string
+          format: date-time
+
+    RefundOfferPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Changes the refund offer to status CONFIRMED. De-confirmation by setting PROPOSED status is not supported by API.
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/RefundStatus'
+
+    CancelFulfillmentsStatus:
+      type: string
+      enum:
+        - PROPOSED
+        - CONFIRMED
+
+    RefundStatus:
+      type: string
+      enum:
+        - PROPOSED
+        - CONFIRMED
+
+    OverruleCode:
+      description: >-
+        Reason for and type of an after sale, code list in IRS 90918-10.
+        The PRM_SUPPORT_UNAVAILABLE overrule code shall only be used by the UIC PRM ABT tool.
+      type: string
+      x-extensible-enum:
+        - CONNECTION_BROKEN
+        - EQUIPMENT_FAILURE
+        - PAYMENT_FAILURE
+        - PRM_SUPPORT_UNAVAILABLE
+        - SALES_STAFF_ERROR
+        - STOP_NOT_SERVED
+        - STRIKE
+        - TECHNICAL_FAILURE
+        - TICKET_NOT_USED
+
+    ExchangeOfferCollectionRequest:
+      description: >-
+        Defines the parameters needed to request an exchange offer, either based on either an
+        existing trip (that is then passed in) plus a set of offer search
+        criteria, or based on trip-search and offer search criteria. At least one
+        of the trip or tripSearchCriteria must be set.
+      allOf:
+        - $ref: '#/components/schemas/OfferCollectionRequest'
+        - type: object
+          additionalProperties: false
+          required:
+            - fulfillmentIds
+          properties:
+            fulfillmentIds:
+              type: array
+              items:
+                type: string
+              minItems: 1
+              nullable: false
+            overruleCode:
+              $ref: '#/components/schemas/OverruleCode'
+
+    ExchangeOfferCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        exchangeOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExchangeOffer'
+        trips:
+          description: >-
+            Two trips are returned if  round trips are exchanged.
+          type: array
+          items:
+            $ref: '#/components/schemas/Trip'
+        passengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ExchangeOperationResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        exchangeOperation:
+          $ref: '#/components/schemas/ExchangeOperation'
+
+    ExchangeOperation:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          nullable: false
+        status:
+          $ref: '#/components/schemas/ExchangeStatus'
+        exchangeOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExchangeOffer'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+        ticketTimeLimit:
+          type: string
+          format: date-time
+        fulfillmentType:
+          $ref: '#/components/schemas/FulfillmentType'
+
+    ExchangeStatus:
+      type: string
+      enum:
+        - PREBOOKED
+        - CONFIRMED
+        - FULFILLED
+        - ERROR
+
+    ExchangeOperationPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Allows modifying a general setting for the booking:
+         * setting the required fulfillment type, e.g. value paper
+           or e-ticket and preferred fulfillment media.
+           The latter is optional and relevant in some cases only.
+         * Provisionally exchanging some of the fulfillments in the booking
+      properties:
+        requestedFulfillmentType:
+          $ref: '#/components/schemas/FulfillmentType'
+        preferredFulfillmentMedia:
+          $ref: '#/components/schemas/FulfillmentMediaType'
+        embed:
+          description: >-
+            Influences whether referenced resources are returned in full or as references only.
+          type: array
+          items:
+            $ref: '#/components/schemas/ExchangeOperationResponseContent'
+
+    ExchangeOffer:
+      allOf:
+        - $ref: '#/components/schemas/Offer'
+        - type: object
+          additionalProperties: false
+          properties:
+            exchangeFee:
+              $ref: '#/components/schemas/Price'
+            exchangePrice:
+              $ref: '#/components/schemas/Price'
+            fulfillments:
+              type: array
+              items:
+                $ref: '#/components/schemas/Fulfillment'
+
+    CoachLayoutCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        layouts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachLayout'
+
+    CoachLayoutResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        coachLayout:
+          $ref: '#/components/schemas/CoachLayout'
+
+    CoachLayout:
+      type: object
+      additionalProperties: false
+      description: >-
+        coach layout providing data to draw a coach layout. The items of a coach
+        are located via coordinates with (0,0) in the upper left corner. All
+        coordinates are given without sign.
+      required:
+        - id
+      properties:
+        id:
+          description: >-
+            id of this coachLayout on this server
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the coach layout.
+          type: string
+          example: Coach 3 in train T-122
+        places:
+          description: >-
+            list of places included in the layout
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachLayoutPlace'
+        signs:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachLayoutSign'
+        internals:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachLayoutInternal'
+        gridSize:
+          $ref: '#/components/schemas/CoachLayoutGridSize'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    CoachLayoutPlace:
+      type: object
+      additionalProperties: false
+      required:
+        - number
+        - coords
+      properties:
+        number:
+          description: >-
+            place number as displayed physically on the place
+          type: string
+          nullable: false
+        direction:
+          $ref: '#/components/schemas/DirectionType'
+        remarkId:
+          $ref: '#/components/schemas/RemarkType'
+        coords:
+          $ref: '#/components/schemas/LayoutCoordinates'
+
+    CoachLayoutSign:
+      type: object
+      additionalProperties: false
+      required:
+        - icon
+        - coords
+      properties:
+        icon:
+          description: >-
+            Icon type of the graphical item type. Code list according to UIC90918-1
+            graphical item type e.g. silence area sign = 116
+            
+          type: string
+          nullable: false
+        coords:
+          $ref: '#/components/schemas/LayoutCoordinates'
+
+    CoachLayoutInternal:
+      type: object
+      additionalProperties: false
+      required:
+        - icon
+        - coords
+      properties:
+        icon:
+          type: string
+          nullable: false
+        mounting:
+          $ref: '#/components/schemas/MountingType'
+        coords:
+          $ref: '#/components/schemas/LayoutCoordinates'
+
+    DirectionType:
+      description: >-
+        Direction of a place, defined optional as it might be omitted in
+        case of berths in future. 
+        Code list according to UIC90918-1
+        Valid Values:
+        - RIGHT: to right
+        - LEFT: to left
+        - UP: up (from right side of a coach pointing to the middle of the aisle)
+        - DOWN: down (from right side of the coach pointing to the middle of the aisle)
+      type: string
+      enum:
+        - RIGHT
+        - LEFT
+        - UP
+        - DOWN
+
+    RemarkType:
+      description: >-
+        Remark concerning the place (e.g. to be used in a tool tip).
+        Code list according to UIC90918-1
+        Known Values:
+        - MIGHT_HAVE_TABLE: place might have a table
+        - MIGHT_NOT_HAVE_TABLE: table at the place might be missing
+        - MIGHT_HAVE_DIFFERENT_DIRECTION: place might have a different direction
+        - MIGHT_HAVE_TABLE_AND_DIFFERENT_DIRECTION: place might have a table and a different direction
+        - MIGHT_NOT_HAVE_TABLE_AND_MIGHT_HAVE_DIFFERENT_DIRECTION: table at the place might be missing and place might have a different direction
+        - MIGHT_BE_IN_COMPARTMENT: place might be in compartment
+        - MIGHT_BE_IN_OPEN_SPACE: place might be in open space
+      type: string
+      x-extensible-enum:
+        - MIGHT_HAVE_TABLE
+        - MIGHT_NOT_HAVE_TABLE
+        - MIGHT_HAVE_DIFFERENT_DIRECTION
+        - MIGHT_HAVE_TABLE_AND_DIFFERENT_DIRECTION
+        - MIGHT_NOT_HAVE_TABLE_AND_MIGHT_HAVE_DIFFERENT_DIRECTION
+        - MIGHT_BE_IN_COMPARTMENT
+        - MIGHT_BE_IN_OPEN_SPACE
+
+    MountingType:
+      type: string
+      enum:
+        - UPPER_BORDER
+        - LOWER_BORDER
+        - UPPER_TO_LOWER_BORDER
+        - FREE
+
+    LayoutCoordinates:
+      type: object
+      additionalProperties: false
+      required:
+        - x
+        - y
+        - zOrder
+      properties:
+        x:
+          description: >-
+            horizontal coordinate of the center of the place
+          type: integer
+          format: int32
+          nullable: false
+        y:
+          description: >-
+            vertical coordinate of the center of the place
+          type: integer
+          format: int32
+          nullable: false
+        zOrder:
+          description: >-
+            Graphical layer where this item has to be placed.
+            Code list according to UIC90918-1
+              - value 0: lowest layer usually used for walls
+              - value 1: middle layer usually used by places
+              - value 2: top layer usually used by icons
+          type: string
+          nullable: false
+
+    Problem:
+      type: object
+      additionalProperties: false
+      description: >-
+        Problem Details for HTTP APIs (RFC 7807) defines a 'problem detail' as a way
+        to carry machine-readable details of errors in a HTTP response to avoid
+        the need to define new error response formats for HTTP APIs.
+        See: https://tools.ietf.org/html/rfc7807
+      properties:
+        type:
+          description: >-
+            An absolute URI that identifies the problem type. When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          type: string
+          format: uri
+          default: 'about:blank'
+          example: https://example.com/probs/passenger-too-young
+        title:
+          description: >-
+            A short, summary of the problem type. Written in English and readable
+            for engineers (usually not suited for non technical stakeholders and
+            not localized);
+          type: string
+          example: Service Unavailable
+        status:
+          description: >-
+            The HTTP status code generated by the origin server for this occurrence
+            of the problem.
+          type: integer
+          format: int32
+          maximum: 600
+          exclusiveMaximum: true
+          minimum: 100
+          example: 503
+        detail:
+          description: >-
+            A human readable explanation specific to this occurrence
+            of the problem.
+          type: string
+          example: Connection to database timed out
+        instance:
+          description: >-
+            An absolute URI that identifies the specific occurrence of the problem.
+          type: string
+          format: uri
+
+    PlaceAvailabilityCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        availablePlaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailablePlace'
+
+    ComplaintResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - complaint
+      properties:
+        complaint:
+          $ref: '#/components/schemas/Complaint'
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+
+    CustomerComplaint:
+      type: object
+      additionalProperties: false
+      description: >-
+        complaint details provided by the passengers
+      properties:
+        applicationTime:
+          description: >-
+            date and time when the claim was made. This starts the legal time line to process the claim
+          type: string
+          format: date-time
+        journeyDetails:
+          $ref: '#/components/schemas/ClaimedJourneyDetails'
+        claimManager:
+          $ref: '#/components/schemas/PersonDetail'
+        affectedPassengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+        supportingDocuments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SupportingDocument'
+        bookingIds:
+          description: >-
+            list of booking Ids
+          type: array
+          items:
+            type: string
+        ticketControlNumber:
+          description: >-
+            list of ticket control number (visible ticket identification for the customer)
+          type: array
+          items:
+            type: string
+        requestedPaymentType:
+          $ref: '#/components/schemas/PaymentType'
+        bankAccount:
+          $ref: '#/components/schemas/BankAccountReference'
+
+    PaymentType:
+      type: string
+      x-extensible-enum:
+        - CARD
+        - CASH
+        - DIRECT_DEBIT
+        - ELECTRONIC_PAYMENT
+        - INVOICE
+        - VOUCHER
+
+    BankAccountReference:
+      type: object
+      additionalProperties: false
+      description: >-
+        bank account
+      properties:
+        iban:
+          description: >-
+            IBAN to be used in Europe
+          type: string
+          pattern: '[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}'
+        accountId:
+          description: >-
+            bank account id to be used outside of EU
+          type: string
+        bankIdCode:
+          $ref: '#/components/schemas/BankIdCode'
+        bankId:
+          type: string
+        ownerName:
+          type: string
+          example: John Doe
+
+    BankIdCode:
+      type: string
+      x-extensible-enum:
+        - SWIFT
+
+    SupportingDocument:
+      type: object
+      additionalProperties: false
+      description: >-
+        The supporting document helps to support the request.
+      required:
+        - title
+        - format
+      properties:
+        title:
+          description: >-
+            title of the document
+          type: string
+          nullable: false
+          example: delay confirmation written by staff on board
+        content:
+          description: >-
+            base64 encoded binary of the actual document
+          type: string
+          format: byte
+        format:
+          description: >-
+            Physical format of the document provided in the content field in Mime-Type format, e.g. 
+            application/pdf, image/jpeg, etc. Must be filled if the 'content' field is present.
+          type: string
+          nullable: false
+          example: application/pdf
+
+    ClaimedJourneyDetails:
+      type: object
+      additionalProperties: false
+      properties:
+        impact:
+          $ref: '#/components/schemas/ImpactType'
+        finalDelay:
+          type: string
+          format: duration
+          example: PT30M
+        onReturn:
+          type: boolean
+          default: false
+        delayedJourney:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClaimedLeg'
+
+    ImpactType:
+      description: >-
+        Known Values:
+        - DELAY: delayed arrival
+        - JOURNEY_ABANDONED: trip way abandoned during the travel
+        - JOURNEY_NOT_STARTED: trip was not started due to the delay
+        - SERVICE_DEGRADED: e.g. service class not provided
+      type: string
+      x-extensible-enum:
+        - DELAY
+        - JOURNEY_ABANDONED
+        - JOURNEY_NOT_STARTED
+        - SERVICE_DEGRADED
+
+    ClaimedLeg:
+      type: object
+      additionalProperties: false
+      properties:
+        trainNumber:
+          type: string
+        connectionMissed:
+          description: >-
+            connection missed due to a delay on the previous leg
+          type: boolean
+        serviceDegradation:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceDegradation'
+        departureStation:
+          $ref: '#/components/schemas/Place'
+        arrivalStation:
+          $ref: '#/components/schemas/Place'
+        plannedDepartureTime:
+          type: string
+          format: date-time
+        timetabledArrivalTime:
+          type: string
+          format: date-time
+        observedArrivalTime:
+          type: string
+          format: date-time
+
+    ServiceDegradation:
+      description: >-
+        enumeration of service degradations
+      type: string
+      x-extensible-enum:
+        - RESERVED_PLACES_MISSING
+        - BOOKED_ACCOMMODATION_TYPE_MISSING
+        - BOOKED_CLASS_MISSING
+        - BOOKED_MEAL_MISSING
+
+    ComplaintPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Changes to a claim already made.
+        This covers upload of additional supporting documents, changes to  the passenger and claim manager data.
+        The patch of the compensation amount requires an agreement between the involved parties and is used in
+        case the legal time line for deciding the claim is passed.
+      properties:
+        reason:
+          $ref: '#/components/schemas/ComplaintChangeReason'
+        compensationAmount:
+          $ref: '#/components/schemas/Price'
+        claimManager:
+          $ref: '#/components/schemas/PersonDetail'
+        affectedPassengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+        supportingDocuments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SupportingDocument'
+        bankAccount:
+          $ref: '#/components/schemas/BankAccountReference'
+
+    ComplaintChangeReason:
+      description: >-
+        Known Values:
+        - BANK_ACCOUNT
+        - SETTLED_TIME_LIMIT_EXCEEDED: an allocator settled the claim as the fare provided did not reply in due time. The compensation amount debited is provided
+        - PASSENGER_CHANGE
+      type: string
+      x-extensible-enum:
+        - BANK_ACCOUNT
+        - SETTLED_TIME_LIMIT_EXCEEDED
+        - PASSENGER_CHANGE
+
+    Complaint:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          nullable: false
+        status:
+          $ref: '#/components/schemas/BackOfficeStatus'
+        customerComplaint:
+          $ref: '#/components/schemas/CustomerComplaint'
+        missingInformation:
+          description: >-
+            indication of missing customer information
+          type: array
+          items:
+            type: string
+        decision:
+          $ref: '#/components/schemas/ComplaintDecision'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    BackOfficeStatus:
+      description: >-
+        Status of the request sent to the back office.
+      type: string
+      enum:
+        - INITIATED
+        - EVALUATING
+        - DECIDED
+        - SETTLED
+        - INFORMATION_MISSING
+
+    ComplaintDecision:
+      type: object
+      additionalProperties: false
+      properties:
+        compensationAmount:
+          $ref: '#/components/schemas/Price'
+        refundVoucher:
+          $ref: '#/components/schemas/FulfillmentDocument'
+        explanation:
+          $ref: '#/components/schemas/SupportingDocument'
+        shortExplanation:
+          type: string
+        delayedJourney:
+          description: >-
+            Allocator or fare provider view on the delays. This might differ from the customer view.
+          type: array
+          items:
+            $ref: '#/components/schemas/Trip'
+
+    ReductionCardCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        reductionCardsDelivery:
+          $ref: '#/components/schemas/ReductionCardsDelivery'
+
+    ZoneCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        zonesDelivery:
+          $ref: '#/components/schemas/ZonesDelivery'
+
+    ReductionCardsDelivery:
+      type: object
+      additionalProperties: false
+      description: >-
+        Delivery of a list of reduction cards.
+      properties:
+        deliveryDate:
+          description: >-
+            date of the assembly of the reduction card data set
+          type: string
+          format: date-time
+        reductionCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReductionCard'
+
+    ZonesDelivery:
+      type: object
+      additionalProperties: false
+      description: >-
+        Delivery of a list of zones
+      properties:
+        deliveryDate:
+          description: >-
+            date of the assembly of the zones data set
+          type: string
+          format: date-time
+        zones:
+          type: array
+          items:
+            $ref: '#/components/schemas/ZoneDefinition'
+
+    ReductionCard:
+      type: object
+      additionalProperties: false
+      required:
+        - issuer
+        - id
+        - name
+      properties:
+        issuer:
+          $ref: '#/components/schemas/CompanyRef'
+        id:
+          description: >-
+            id of the card type within the issue
+          type: string
+          nullable: false
+        name:
+          $ref: '#/components/schemas/Text'
+        includedCards:
+          description: >-
+            This card includes the listed cards
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+        serviceClassTypes:
+          description: >-
+            list of service classes where this card applies
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceClassType'
+          maxItems: 4
+        cardType:
+          $ref: '#/components/schemas/CardType'
+        cardIdRequired:
+          description: >-
+            the card id must be delivered in online sales
+          type: boolean
+          default: false
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ZoneDefinition:
+      type: object
+      additionalProperties: false
+      description: >-
+        Definition of a zone used to define regional validity. The area of the zone can be defined via a
+        geo-polygon, a complete list of all contained stations or area codes from the NUTS code list.
+        The carrier is either the carrier or transport authority responsible for the definition.
+      required:
+        - id
+        - carrier
+      properties:
+        id:
+          type: string
+          nullable: false
+        name:
+          type: string
+        carrier:
+          $ref: '#/components/schemas/CompanyRef'
+        polygon:
+          $ref: '#/components/schemas/Polygon'
+        nutsCodes:
+          type: array
+          items:
+            type: string
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceRef'
+
+    Fare:
+      type: object
+      additionalProperties: false
+      description: >-
+        The online representation of a fare.
+      required:
+        - id
+        - type
+        - prices
+        - regionalConstraint
+        - travelClass
+        - afterSalesCondition
+        - combinationConstraint
+        - travelValidityConstraint
+        - requiredCards
+      properties:
+        id:
+          description: >-
+            id of the fare item to be included in accounting
+          type: string
+          nullable: false
+        type:
+          $ref: '#/components/schemas/FareType'
+        name:
+          $ref: '#/components/schemas/Text'
+        description:
+          $ref: '#/components/schemas/Text'
+        prices:
+          description: >-
+            allows specifying a price in multiple currencies
+          type: array
+          items:
+            $ref: '#/components/schemas/Price'
+          minItems: 1
+        regionalConstraint:
+          $ref: '#/components/schemas/RegionalConstraint'
+        serviceConstraint:
+          $ref: '#/components/schemas/ServiceConstraint'
+        carrierConstraint:
+          $ref: '#/components/schemas/CarrierConstraint'
+        regulatoryConditions:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegulatoryCondition'
+        serviceClass:
+          $ref: '#/components/schemas/ServiceClass'
+        travelClass:
+          $ref: '#/components/schemas/TravelClass'
+        afterSalesCondition:
+          $ref: '#/components/schemas/AfterSalesConditionsLink'
+        combinationConstraint:
+          type: array
+          items:
+            $ref: '#/components/schemas/FareCombinationModel'
+          minItems: 1
+        fulfillmentConstraint:
+          $ref: '#/components/schemas/FulfillmentConstraint'
+        travelValidityConstraint:
+          $ref: '#/components/schemas/TravelValidity'
+        availablePlaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailablePlace'
+        placeSelection:
+          $ref: '#/components/schemas/PlaceSelection'
+        placeAllocation:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceAllocation'
+        coveredSection:
+          $ref: '#/components/schemas/Section'
+        passengerConstraints:
+          description: >-
+            passenger constraint to be included in bar codes
+          type: array
+          items:
+            $ref: '#/components/schemas/PassengerConstraints'
+        involvedTCOs:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyRef'
+        legacyAccountingIdentifier:
+          $ref: '#/components/schemas/LegacyAccountingIdentifier'
+        legacyReservationParameter:
+          $ref: '#/components/schemas/LegacyReservationParameter'
+        requiredCards:
+          description: >-
+            One of the listed cards is required to be valid at the time of travel.
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+          minItems: 1
+        luggageConstraint:
+          $ref: '#/components/schemas/LuggageConstraint'
+        availablePreferences:
+          type: array
+          items:
+            $ref: '#/components/schemas/AvailablePlacePreferences'
+
+    RegionalConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        Regional constraint of the fare- offline bulk data use the id of connection points whereas  in an online environment the connection point is included
+      required:
+        - regionalValidities
+      properties:
+        entryConnectionPoint:
+          $ref: '#/components/schemas/FareConnectionPoint'
+        exitConnectionPoint:
+          $ref: '#/components/schemas/FareConnectionPoint'
+        regionalValidities:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegionalValidity'
+          minItems: 1
+        distance:
+          description: >-
+            Distance in km for statistics
+          type: integer
+          format: int32
+          minimum: 0
+
+    AfterSalesConditionsLink:
+      type: object
+      additionalProperties: false
+      required:
+        - conditions
+      properties:
+        conditions:
+          description: >-
+            Structured description of the after-sales conditions.
+          type: array
+          items:
+            $ref: '#/components/schemas/AfterSaleCondition'
+          minItems: 1
+        isSupportingIndividualContracts:
+          description: >-
+            Indicates that the after sales of this fare can be treated independently per person.
+          type: boolean
+          default: false
+
+    FulfillmentConstraint:
+      type: object
+      additionalProperties: false
+      required:
+        - acceptedControlSecurityTypes
+      properties:
+        acceptedControlSecurityTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ControlSecurityType'
+          minItems: 1
+        acceptedBarCodes:
+          description: >-
+            for SiD fulfillment one of the listed bar codes is required
+          type: array
+          items:
+            $ref: '#/components/schemas/BarCodeType'
+        requiredBarCodes:
+          description: >-
+            One of the listed bar codes must be provided.
+          type: array
+          items:
+            $ref: '#/components/schemas/BarCodeType'
+        requiredSiS:
+          type: array
+          items:
+            $ref: '#/components/schemas/SiSType'
+        isIndividualTicketingForbidden:
+          description: >-
+            a separate fulfillment per passenger is forbidden
+          type: boolean
+          default: false
+
+    TravelValidity:
+      type: object
+      additionalProperties: false
+      description: >-
+        travel validity data are needed to create barcode and control data (IRS 90918-4)
+        in allocator mode even in case they have been checked during the online sale
+      required:
+        - validityRange
+      properties:
+        validTravelDates:
+          $ref: '#/components/schemas/Calendar'
+        validityRange:
+          $ref: '#/components/schemas/ValidityRange'
+        excludedTimeRanges:
+          description: >-
+            time ranges excluded from the validity (e.g. off peak fulfillments)
+          type: array
+          items:
+            $ref: '#/components/schemas/ExcludedTimeRange'
+        numberOfTravelDays:
+          description: >-
+            number of allowed travel days (e.g. 3 travel days within 2 weeks)
+          type: integer
+          format: int32
+        returnConstraint:
+          $ref: '#/components/schemas/ReturnConstraint'
+        trainValidity:
+          $ref: '#/components/schemas/TrainValidity'
+        validityType:
+          $ref: '#/components/schemas/ValidityType'
+        tripAllocationConstraint:
+          $ref: '#/components/schemas/TripAllocationConstraint'
+        tripInterruptionConstraint:
+          $ref: '#/components/schemas/TripInterruptionConstraint'
+
+    PassengerConstraints:
+      type: object
+      additionalProperties: false
+      properties:
+        number:
+          description: >-
+            number of passengers with this constraint
+          type: integer
+          format: int32
+        upperAgeLimit:
+          type: integer
+          format: int32
+        lowerAgeLimit:
+          type: integer
+          format: int32
+
+    LegacyAccountingIdentifier:
+      type: object
+      additionalProperties: false
+      description: >-
+        identifier of the fare in the current 301 accounting file
+      required:
+        - serialId
+      properties:
+        serialId:
+          description: >-
+            sequential number of regional validities
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 99999
+          nullable: false
+        addId:
+          description: >-
+            Sequential number of regional validities (leading positions in case the series
+            is too short).
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 99
+        tariffId:
+          description: >-
+            Tarif id for the old serie format.
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 9999
+
+    LegacyReservationParameter:
+      type: object
+      additionalProperties: false
+      description: >-
+        reservation parameter to support the UIC 90918-1 interface for booking
+      required:
+        - travelClass
+        - serviceLevelCode
+        - serviceCode
+      properties:
+        travelClass:
+          description: >-
+            90918-1 class code in reservation
+          type: string
+          nullable: false
+        serviceLevelCode:
+          description: >-
+            service level code defined in UIC 90918-1
+          type: string
+          nullable: false
+        serviceCode:
+          description: >-
+            service code to be used in reservation
+          type: string
+          nullable: false
+        berthType:
+          description: >-
+            berth type code in UIC 90918-1 to be used in reservation
+          type: string
+        coachTypeCode:
+          description: >-
+            coach type code in UIC 90918-1 to be used in reservation
+          type: string
+        compartmentTypeCode:
+          description: >-
+            compartment type code in UIC 90918-1 to be used in reservation
+          type: string
+        tariffs:
+          description: >-
+            tariff according to UIC 90918-1 to be used for booking
+          type: array
+          items:
+            $ref: '#/components/schemas/LegacyReservationTariff'
+
+    BarCodeType:
+      description: >-
+        Item according to IRS 90918-9: FCB, TLB, SSB
+      type: string
+      x-extensible-enum:
+        - FCB
+        - TLB
+        - SSB
+
+    SiSType:
+      type: string
+      x-extensible-enum:
+        - REGISTRY
+        - PEER_TO_PEER
+
+    TripInterruptionProcess:
+      description: >-
+        Known Values:
+        - NONE
+        - MANUAL: passenger needs manual confirmation of train or station staff to interrupt the trip.
+        - ACTIVATION: Passenger needs to deactivate the ticket during the interruption (via an app).
+      type: string
+      x-extensible-enum:
+        - NONE
+        - MANUAL
+        - ACTIVATION
+
+    TripAllocationProcess:
+      description: >-
+        Known Values:
+        - NONE: Individual trips don't need to be allocated.
+        - MANUAL: The passenger has to allocate a trip manually (This should not be used as it is by design non-interoperable).
+        - ACTIVATION: Individual trips can be allocated by activation of the ticket.
+        - FULFILLMENT: A new fulfillment needs to be created to allocate a trip.
+      type: string
+      x-extensible-enum:
+        - NONE
+        - MANUAL
+        - ACTIVATION
+        - FULFILLMENT
+
+    TripAllocationUnit:
+      description: >-
+        Unit to allocate trips in a multi-trip fare. Trips can be allocated per day (e.g. Eurail) or per
+        duration (e.g. multiples of a duration unit to cover the trip) or as single trips (e.g. carnet))
+        Known Values:
+        - NONE: Individual trips don't need to be allocated. 
+        - TRIP: allocation per individual trip.
+        - DAY: The allocation is per travel day.
+        - DURATION: the allocation is per duration.
+      type: string
+      x-extensible-enum:
+        - NONE
+        - TRIP
+        - DAY
+        - DURATION
+
+    TripAllocationConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        constraint on the use of a multiple trip ticket
+      required:
+        - allocationUnit
+        - requiredProcesses
+      properties:
+        allocationUnit:
+          $ref: '#/components/schemas/TripAllocationUnit'
+        maxUnits:
+          description: >-
+            maximum number of allowed units to be allocated
+          type: integer
+          format: int32
+        durationUnit:
+          description: >-
+            multiples of this duration can be allocated
+          type: string
+          format: duration
+          example: PT30M
+        requiredProcesses:
+          description: >-
+            one of the listed processes is required for the allocation of a single trip
+          type: array
+          items:
+            $ref: '#/components/schemas/TripAllocationProcess'
+          minItems: 1
+
+    TripInterruptionConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        rules on allowed trip interruptions. Interruptions due to a train change
+        indicated by a trip search must not be included here.
+      required:
+        - maxInterruptions
+        - requiredProcesses
+      properties:
+        maxInterruptions:
+          description: >-
+            maximum number of allowed interruptions
+          type: integer
+          format: int32
+          nullable: false
+        maxDuration:
+          description: >-
+            maximum duration of one interruption
+          type: string
+          format: duration
+          example: PT30M
+        totalMaxDuration:
+          description: >-
+            maximum duration of all interruptions on the route
+          type: string
+          format: duration
+          example: PT30M
+        requiredProcesses:
+          description: >-
+            one of the listed processes is required for the interruption of the trip
+          type: array
+          items:
+            $ref: '#/components/schemas/TripInterruptionProcess'
+          minItems: 1
+
+    RegulatoryCondition:
+      description: >-
+        General conditions applied to cover legal regulations within the area of validity. Allocators must
+        reflect these terms and conditions in the conditions of combined offers and indicate them to the customer
+        where required. Which indications are mandatory to be shown to the customer is defined in the SCICs.
+        
+        Valid Values:
+        - CIV: terms and conditions according to COTIV regulation
+        - MD: terms and conditions according to SMPS regulation
+        - EU_PRR: terms and conditions according to EU-PRR regulation
+      type: string
+      enum:
+        - CIV
+        - MD
+        - EU_PRR
+
+    Calendar:
+      type: object
+      additionalProperties: false
+      properties:
+        from:
+          type: string
+          format: date-time
+        until:
+          type: string
+          format: date-time
+        dates:
+          description: >-
+            dates included in the calendar. In case no dates are provided the range is assumed to be valid
+          type: array
+          items:
+            type: string
+            format: date-time
+        utcOffset:
+          description: >-
+            offset to UTC in minutes (number of minutes to be added to get UTC dates)
+          type: integer
+          format: int32
+
+    FareCombinationModel:
+      type: object
+      additionalProperties: false
+      required:
+        - model
+      properties:
+        model:
+          description: >-
+            Possible models are SEPARATE_TICKET, SEPARATE_CONTRACT, CLUSTERING, COMBINING.
+            The models need to be supported by the allocator.
+          type: string
+          nullable: false
+        combinableCarriers:
+          description: >-
+            List of all carriers where the model can be applied, in case the list is empty
+            all combinations are allowed.
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyRef'
+        isValidOnlyWhenCombined:
+          description: >-
+            This combination model applies only in case the fare is combined with another carrier
+          type: boolean
+          default: false
+        referenceCluster:
+          description: >-
+            In case of CLUSTERING model: the cluster to which the fare belongs
+          type: string
+        allowedClusters:
+          description: >-
+            In case of CLUSTERING model: the other clusters that allow a combination
+          type: array
+          items:
+            type: string
+        allowedCommonContracts:
+          description: >-
+            List of carriers where a common contract with separate fulfillments are allowed.
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyRef'
+
+    ServiceConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        Either excluded or included service brands can be set.
+      properties:
+        restrictedToServiceBrands:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBrandCode'
+        excludedServiceBrands:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBrandCode'
+        description:
+          $ref: '#/components/schemas/Text'
+
+    RegionalValidity:
+      type: object
+      additionalProperties: false
+      description: >-
+        One of the elements Zone, ViaStation, TrainLink, Line, or Polygon defining the regional validity
+      properties:
+        seqNb:
+          description: >-
+            order number of the list item
+          type: integer
+          format: int32
+        zone:
+          $ref: '#/components/schemas/Zone'
+        route:
+          $ref: '#/components/schemas/Route'
+        trainLink:
+          $ref: '#/components/schemas/TrainLink'
+        line:
+          $ref: '#/components/schemas/Line'
+        polygon:
+          $ref: '#/components/schemas/Polygon'
+        serviceConstraint:
+          $ref: '#/components/schemas/ServiceConstraint'
+
+    Line:
+      type: object
+      additionalProperties: false
+      description: >-
+        terminalStation - in case the product requires a destination within the zone (e.g. local ticket
+        to go to the main rail station).
+        entryStation - Station to enter the zone in case the product requires to enter the zone via a
+        specific station (e.g. local zone ticket to start from the main rail station).
+      required:
+        - carrier
+      properties:
+        binaryLineId:
+          description: >-
+            Id to support local traffic standards (e.g. VDV,...).
+          type: string
+          format: byte
+        carrier:
+          $ref: '#/components/schemas/CompanyRef'
+        city:
+          type: integer
+          format: int32
+        entryStation:
+          $ref: '#/components/schemas/StopPlace'
+        lineIds:
+          type: array
+          items:
+            type: string
+        terminalStation:
+          $ref: '#/components/schemas/StopPlace'
+        nutsCode:
+          description: >-
+            Nomenclature des units territoriales statistiques
+             COMMISSION REGULATION (EU) No 31/2011
+          type: string
+
+    TrainLink:
+      type: object
+      additionalProperties: false
+      required:
+        - fromStation
+        - toStation
+        - train
+        - travelDate
+        - serviceBrandCode
+        - serviceBrandAbbreviation
+      properties:
+        fromStation:
+          $ref: '#/components/schemas/StopPlaceRef'
+        toStation:
+          $ref: '#/components/schemas/StopPlaceRef'
+        train:
+          type: string
+          nullable: false
+        travelDate:
+          description: >-
+            date and time of the departure where the train link starts
+          type: string
+          format: date-time
+          nullable: false
+        serviceBrandCode:
+          $ref: '#/components/schemas/ServiceBrandCode'
+        serviceBrandAbbreviation:
+          description: >-
+            Abbreviation of the service brand, e.g. "IC", "TGV". See the OSDM code list. Needs to match the service brand code.
+          type: string
+          nullable: false
+
+    Polygon:
+      type: object
+      additionalProperties: false
+      required:
+        - edges
+      properties:
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeoPosition'
+          minItems: 1
+
+    Route:
+      type: object
+      additionalProperties: false
+      description: >-
+        Route description including the first and last real stopPoint
+      properties:
+        routeItem:
+          $ref: '#/components/schemas/RouteItem'
+        routeItemList:
+          description: >-
+            list of route items referenced within the list
+          type: array
+          items:
+            $ref: '#/components/schemas/RouteItem'
+
+    RouteItem:
+      type: object
+      additionalProperties: false
+      description: >-
+        Items to compose routes (Note - replaced viaStation, content compliant with viaStation in IRS 90918-4 and 90918-9)
+      properties:
+        alternativeRouteItemIndices:
+          description: >-
+            list of alternative route parts to be used on this travel path referenced by the index in the provided list of route items
+          type: array
+          items:
+            type: integer
+            format: int32
+        carrierConstraint:
+          $ref: '#/components/schemas/CarrierConstraint'
+        routeItemIndices:
+          description: >-
+            sequence of route items along the travel path referenced by the index in the provided list of route items
+          type: array
+          items:
+            type: integer
+            format: int32
+        serviceConstraint:
+          $ref: '#/components/schemas/ServiceConstraint'
+        station:
+          $ref: '#/components/schemas/StopPlace'
+        fareReferenceStation:
+          $ref: '#/components/schemas/FareReferenceStation'
+
+    FareReferenceStation:
+      type: object
+      additionalProperties: false
+      description: >-
+        Reference to a list of stations jointly valid in a fare. The fare
+        reference station defines a set of station that are equivalent from
+        a tariff point of view. The code is issued by the carrier. Needed to
+        generate bar codes as well as fulfillments.
+      required:
+        - name
+        - code
+        - carrier
+        - stations
+      properties:
+        name:
+          type: string
+          nullable: false
+        code:
+          type: string
+          nullable: false
+        carrier:
+          $ref: '#/components/schemas/CompanyRef'
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/StopPlaceRef'
+          minItems: 1
+
+    CarrierConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        Either excluded or included carriers can be set.
+      properties:
+        includedCarriers:
+          type: array
+          items:
+            type: string
+        excludedCarriers:
+          type: array
+          items:
+            type: string
+
+    Zone:
+      type: object
+      additionalProperties: false
+      description: >-
+        carrier - carrier responsible for the transport.
+        entryStation - Station to enter the zone in case the product requires to enter the zone via a specific station
+        (e.g. local zone ticket to start from the main rail station).
+        terminalStation - Terminal station in case the product requires a destination within the zone (e.g. local ticket
+        to go to the main rail station).
+      required:
+        - carrier
+      properties:
+        binaryZoneId:
+          description: >-
+            Id to support local traffic standards (e.g. VDV,...)
+          type: string
+          format: byte
+        carrier:
+          $ref: '#/components/schemas/CompanyRef'
+        name:
+          type: string
+        entryStation:
+          $ref: '#/components/schemas/StopPlace'
+        terminalStation:
+          $ref: '#/components/schemas/StopPlace'
+        zoneIds:
+          description: >-
+            to be used in bar codes
+          type: array
+          items:
+            type: integer
+            format: int32
+        nutsCode:
+          description: >-
+            Nomenclature des units territoriales statistiques COMMISSION REGULATION (EU) No 31/2011
+          type: string
+
+    ControlSecurityType:
+      description: >-
+        Known Values:
+        - SiP: secure paper tickets
+        - SiD: security in data (signed bar code)
+        - SiS: security in system
+      type: string
+      x-extensible-enum:
+        - SiP
+        - SiD
+        - SiS
+
+    LegacyReservationTariff:
+      type: object
+      additionalProperties: false
+      description: >-
+        Legacy tariff code and number of items or persons in case UIC 90918-1 is used for booking.
+      properties:
+        number:
+          description: >-
+            number of items with this tariff code
+          type: integer
+          format: int32
+        code:
+          description: >-
+            legacy tariff code
+          type: integer
+          format: int32
+
+    FareType:
+      description: >-
+        Basic UIC fare types used in 90918-10, 90918-4, and 90918-9.
+      type: string
+      x-extensible-enum:
+        - ADMISSION
+        - RESERVATION
+        - INTEGRATED_RESERVATION
+        - ANCILLARY
+
+    FareConnectionPoint:
+      type: object
+      additionalProperties: false
+      description: >-
+        Connection point connecting two fare regimes. The connection is possible between stations of the two provided station sets.
+        A legacy border point code (id) might be provided as an additional code within the stations (code list BORDER_POINT provided in URN).
+        In case the connection point is a real station this station is indicated.
+        In case the connection point is between stations for each side of the border real stations must be provided.
+        Multiple sets of station can be provided in the rare case that the connection point connects more than two station (A-B and A-C).
+        Multiple stations within a set at one side of the border might be provided in case of changes (new stations build near the border).
+        
+        Providing the UIC code for the station is mandatory.
+      required:
+        - stationSets
+      properties:
+        name:
+          type: string
+        stationSets:
+          type: array
+          items:
+            $ref: '#/components/schemas/StationSet'
+          minItems: 1
+
+    StationSet:
+      type: object
+      additionalProperties: false
+      required:
+        - stations
+      properties:
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/StopPlaceRef'
+          minItems: 1
+
+    TrainValidity:
+      type: object
+      additionalProperties: false
+      description: >-
+        Validity depending on boarding / leaving of a train. The ticket is valid
+        from departure until the destination station in the train if departure or destination is within the from - until range.
+        The validation can reference the departure or the destination time to decide the validity (e.g. Eurail/Interrail passes
+        currently use the departure for the validity on night trains).
+      required:
+        - from
+        - until
+        - carriers
+        - scope
+      properties:
+        from:
+          type: string
+          format: date-time
+          nullable: false
+        until:
+          type: string
+          format: date-time
+          nullable: false
+        carriers:
+          type: array
+          items:
+            $ref: '#/components/schemas/CompanyRef'
+          minItems: 1
+        excludedServiceBrands:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBrandCode'
+        includedServiceBrands:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBrandCode'
+        scope:
+          $ref: '#/components/schemas/TrainValidityScope'
+
+    TrainValidityScope:
+      type: string
+      enum:
+        - BOARDING
+        - ARRIVAL
+
+    GeoPosition:
+      type: object
+      additionalProperties: false
+      description: >-
+        WGS84 coordinates position. Provided by OJP.
+      required:
+        - longitude
+        - latitude
+      properties:
+        longitude:
+          $ref: '#/components/schemas/Longitude'
+        latitude:
+          $ref: '#/components/schemas/Latitude'
+
+    Longitude:
+      type: number
+      format: double
+      description: >-
+        Longitude from Greenwich Meridian. -180 (West) to +180 (East). Decimal degrees. eg 2.356.
+      minimum: -180
+      maximum: 180
+      nullable: false
+      example: 8.54021
+
+    Latitude:
+      type: number
+      format: double
+      description: >-
+        Latitude from equator. -90 (South) to +90 (North). Decimal degrees. e.g. 56.356.
+      minimum: -90
+      maximum: 90
+      nullable: false
+      example: 47.37818
+
+    Section:
+      type: object
+      additionalProperties: false
+      description: >-
+        Allows to indicate the sub-part of the trip. LegIds are only relevant if
+        a trip can be referenced. When absent, the totality of the trip is priced.
+      properties:
+        startPlace:
+          $ref: '#/components/schemas/PlaceRef'
+        startLegId:
+          type: string
+        endPlace:
+          $ref: '#/components/schemas/PlaceRef'
+        endLegId:
+          type: string
+
+    Link:
+      type: object
+      additionalProperties: false
+      description: >-
+        The underlying system may provide links for pagination of links pointing on
+        further information (such as HTML download links, web sites or extended APIs).
+        Mechanism to add flexible extensions specific to an underlying system. Implemented
+        the JSON-HAL specification.
+      required:
+        - rel
+        - href
+      properties:
+        rel:
+          description: >-
+            the 'rel' field in HATEOAS navigation.
+          type: string
+          nullable: false
+          example: self
+        href:
+          description: >-
+            Allows to provide a value to the link, for example id of the targeted resource or displayable representation for the link.
+          type: string
+          format: uri
+          nullable: false
+          example: https://api.osdm.com/trips-collections/12345?cursor=2
+        type:
+          description: >-
+            Hint to indicate the media type expected when dereferencing the target resource.
+          type: string
+          example: application/json
+        value:
+          description: >-
+            Allows to provide a value to the link, for example id of the targeted resource or displayable representation for the link.
+          type: string
+
+    Translation:
+      type: object
+      additionalProperties: false
+      required:
+        - language
+        - text
+      properties:
+        language:
+          description: >-
+            ISO-639-1 language code
+          type: string
+          nullable: false
+        text:
+          type: string
+          nullable: false
+        shortText:
+          type: string
+
+    Text:
+      type: object
+      additionalProperties: false
+      description: >-
+        Directly included text in case of online services. Text must be encoded in UTF-8 format.
+      required:
+        - id
+        - text
+      properties:
+        id:
+          type: string
+          nullable: false
+        translations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Translation'
+        text:
+          type: string
+          nullable: false
+        shortText:
+          type: string
+
+    Price:
+      type: object
+      additionalProperties: false
+      required:
+        - currency
+        - amount
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          description: >-
+            amount in cents
+          type: integer
+          format: int32
+          nullable: false
+        scale:
+          description: >-
+            scale of the amount - the number of positions after the comma
+          type: integer
+          format: int32
+          default: 2
+        vats:
+          type: array
+          items:
+            $ref: '#/components/schemas/VAT'
+
+    Currency:
+      type: string
+      description: >-
+        ISO 4217 currency codes
+      nullable: false
+      example: CHF, EUR, SEK
+
+    VAT:
+      type: object
+      additionalProperties: false
+      required:
+        - countryCode
+        - amount
+      properties:
+        countryCode:
+          $ref: '#/components/schemas/CountryCode'
+        amount:
+          description: >-
+            amount in cents
+          type: integer
+          format: int32
+          nullable: false
+          example: 5
+        scale:
+          description: >-
+            scale of the amount - the number of positions after the comma
+          type: integer
+          format: int32
+          default: 2
+        percentage:
+          type: number
+          format: float
+        taxId:
+          type: string
+        scope:
+          $ref: '#/components/schemas/VatScope'
+
+    VatScope:
+      description: >-
+        scope where the VAT applies
+      type: string
+      x-extensible-enum:
+        - INTERNATIONAL
+        - NATIONAL
+        - SHORT_DISTANCE
+        - LONG_DISTANCE
+
+    CompanyRef:
+      type: string
+      description: >-
+        Identifies a company. For rail, a RICS company code or compatible ERA company code are used.
+      nullable: false
+      example: urn:uic:rics:1185:000011
+
+    ServiceBrandCode:
+      type: string
+      description: >-
+        Service brand codes. For public transport, a code list can be found in OSDM's code list. E.g., '163' denotes TGV Lyria and '175' denotes Glacier Express.
+      nullable: false
+      example: 163, 175
+
+    ServiceClass:
+      type: object
+      additionalProperties: false
+      description: >-
+        Class of service.
+      required:
+        - type
+        - name
+      properties:
+        type:
+          $ref: '#/components/schemas/ServiceClassType'
+        name:
+          description: >-
+            The name the carrier itself uses to designate this specific service class.
+          type: string
+          nullable: false
+
+    ServiceClassType:
+      description: >-
+        Type of quality level, finer grained than the comfort class.
+      type: string
+      x-extensible-enum:
+        - BEST
+        - HIGH
+        - STANDARD
+        - BASIC
+        - ANY_CLASS
+
+    Condition:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes sales, usage and after sales conditions applicable to the product.  See after sales conditions for individual after sales amounts.
+      required:
+        - type
+        - description
+        - shortDescription
+      properties:
+        type:
+          $ref: '#/components/schemas/ConditionType'
+        description:
+          type: string
+          minLength: 1
+          nullable: false
+        shortDescription:
+          type: string
+          minLength: 1
+
+    ConditionType:
+      type: string
+      x-extensible-enum:
+        - SALE
+        - PLACE_CHANGE
+        - FULFILLMENT
+        - EXCHANGE
+        - REFUND
+        - TRAVEL
+
+    AvailablePlace:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes the details of the available places.
+      required:
+        - accommodationType
+        - accommodationSubType
+        - tripLegCoverage
+      properties:
+        accommodationType:
+          $ref: '#/components/schemas/AccommodationType'
+        accommodationSubType:
+          $ref: '#/components/schemas/AccommodationSubType'
+        placeProperties:
+          type: array
+          items:
+            type: string
+        numericAvailability:
+          type: integer
+          format: int32
+        tripLegCoverage:
+          $ref: '#/components/schemas/TripLegCoverage'
+
+    PlaceAllocation:
+      type: object
+      additionalProperties: false
+      description: >-
+        Describes the details of the reserved place(s).
+      required:
+        - accommodationType
+        - accommodationSubType
+        - reservedPlaces
+        - tripLegCoverage
+      properties:
+        accommodationType:
+          $ref: '#/components/schemas/AccommodationType'
+        accommodationSubType:
+          $ref: '#/components/schemas/AccommodationSubType'
+        reservedPlaces:
+          description: >-
+            Reserved places in a confirmed reservation.
+            Multiple place packs are needed to combined person and bicycle reservations
+          type: array
+          items:
+            $ref: '#/components/schemas/ReservedPlace'
+          minItems: 1
+        tripLegCoverage:
+          $ref: '#/components/schemas/TripLegCoverage'
+
+    ReservedPlace:
+      type: object
+      additionalProperties: false
+      description: >-
+        Selection of places with common properties description element - textual description of the places
+        placeProperties is mandatory for allocator mode, for distributors the textual description is used
+      required:
+        - id
+        - passengerIds
+        - vehicleNumber
+        - coachNumber
+      properties:
+        id:
+          type: string
+          nullable: false
+        passengerIds:
+          description: >-
+            Id of the passenger
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        vehicleNumber:
+          description: >-
+            vehicle number (e.g. train number)
+          type: string
+          nullable: false
+        coachNumber:
+          type: string
+          nullable: false
+        placeDescription:
+          description: >-
+            description of the places (e.g. 11-35,51)
+          type: string
+        placeNumbers:
+          description: >-
+            list of individual place numbers
+          type: array
+          items:
+            type: string
+        placeProperties:
+          description: >-
+            place properties to be indicated to the customer
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceProperty'
+
+    PlaceProperty:
+      type: string
+      description: >-
+        see code list
+      nullable: false
+      example: Power Connection
+
+    AccommodationType:
+      type: string
+      description: >-
+        Accommodation type definition out of the Accommodation Type Code List
+      default: 'SEAT'
+      nullable: false
+
+    AccommodationSubType:
+      type: string
+      description: >-
+        Accommodation sub type definition out of the Accommodation Sub Type Code List
+      default: 'ANY_SEAT'
+      nullable: false
+
+    PlaceSelection:
+      type: object
+      additionalProperties: false
+      description: >-
+        Place selection options and selected options in an offer
+        - reference place for adjacent reservation
+        - selected optional place properties
+        - selected places from a graphical place selection
+      required:
+        - reservationId
+        - tripLegCoverage
+      properties:
+        reservationId:
+          type: string
+          nullable: false
+        referencePlace:
+          $ref: '#/components/schemas/SelectedReferencePlace'
+        accommodations:
+          type: array
+          items:
+            $ref: '#/components/schemas/SelectedAccommodation'
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/SelectedPlace'
+        tripLegCoverage:
+          $ref: '#/components/schemas/TripLegCoverage'
+
+    AvailablePlacePreferences:
+      type: object
+      additionalProperties: false
+      properties:
+        preferenceGroups:
+          description: >-
+            possible preferences to be requested in reservation without changing the fare
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacePreferenceGroup'
+        graphicalReservation:
+          description: >-
+            graphical reservation is supported, interface type 'NO','UIC_918',..
+          type: string
+
+    PlacePreferenceGroup:
+      type: object
+      additionalProperties: false
+      required:
+        - preferenceGroup
+        - preferences
+      properties:
+        preferenceGroup:
+          type: string
+          nullable: false
+          example: SEAT_DIRECTION
+        preferences:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+          example: FORWARD_FACING
+
+    SelectedReferencePlace:
+      type: object
+      additionalProperties: false
+      description: >-
+        reference place for an adjacent reservation
+      required:
+        - coachNumber
+        - placeNumber
+      properties:
+        coachNumber:
+          type: string
+          nullable: false
+        placeNumber:
+          type: string
+          nullable: false
+
+    SelectedAccommodation:
+      type: object
+      additionalProperties: false
+      description: >-
+        Place selection of places for reservation linked to passengers.
+      required:
+        - passengerRefs
+        - accommodationType
+        - accommodationSubType
+      properties:
+        passengerRefs:
+          description: >-
+            Id of the passenger
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        accommodationType:
+          $ref: '#/components/schemas/AccommodationType'
+        accommodationSubType:
+          $ref: '#/components/schemas/AccommodationSubType'
+        placeProperties:
+          description: >-
+            Properties of places as defined in 90810-10.
+            selection from the optional place properties provided in the offer
+          type: array
+          items:
+            type: string
+
+    PlaceAvailabilityResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        vehicleAvailability:
+          $ref: '#/components/schemas/PlaceAvailability'
+
+    PlaceAvailability:
+      type: object
+      additionalProperties: false
+      description: >-
+        Availability of places on vehicle.
+      required:
+        - vehicle
+      properties:
+        vehicle:
+          $ref: '#/components/schemas/Vehicle'
+        preSelections:
+          description: >-
+            suggested pre-selection of places
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacePreSelection'
+
+    PlacePreSelection:
+      type: object
+      additionalProperties: false
+      properties:
+        coach:
+          type: string
+        place:
+          type: string
+
+    Vehicle:
+      type: object
+      additionalProperties: false
+      description: >-
+        List of the coaches in a vehicle run ordered according to the physical
+        ordering of the vehicle.
+      required:
+        - coaches
+      properties:
+        coaches:
+          type: array
+          items:
+            $ref: '#/components/schemas/Coach'
+          minItems: 1
+
+    Coach:
+      type: object
+      additionalProperties: false
+      required:
+        - compartments
+        - number
+        - status
+        - layoutId
+      properties:
+        compartments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Compartment'
+          minItems: 1
+        number:
+          description: >-
+            coach number
+          type: string
+          nullable: false
+        status:
+          $ref: '#/components/schemas/AvailabilityStatus'
+        layoutId:
+          description: >-
+            id to identify the coach layout
+          type: string
+          nullable: false
+        layoutIdUpperDeck:
+          description: >-
+            id to identify a layout for the upper deck in a double deck coach
+          type: string
+        layoutIdLowerDeck:
+          description: >-
+            id to identify a layout for the lower deck in a double deck coach
+          type: string
+        direction:
+          $ref: '#/components/schemas/TravelDirectionType'
+        owner:
+          $ref: '#/components/schemas/CompanyRef'
+        specialCoach:
+          $ref: '#/components/schemas/SpecialCoachType'
+
+    TravelDirectionType:
+      description: >-
+        indication of the direction of travel standard direction is left
+        to right with ascending coordinates in the layout values.
+      type: string
+      x-extensible-enum:
+        - UNSPECIFIED
+        - IN_DIRECTION
+        - OPPOSITE_DIRECTION
+        - CHANGING
+        - STARING_IN_DIRECTION
+
+    SpecialCoachType:
+      description: >-
+        indication of special coach
+      type: string
+      x-extensible-enum:
+        - RESTAURANT_COACH
+        - BICYCLE_COACH
+        - LUGGAGE_COACH
+        - TRAIN_HEAD
+
+    Compartment:
+      type: object
+      additionalProperties: false
+      description: >-
+        Areas within a coach that holds places. Areas might be selectable
+        as a whole. Usual areas would be classic compartments.
+      required:
+        - places
+        - status
+      properties:
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlacePosition'
+          minItems: 1
+        isSelectable:
+          description: >-
+            Indicates whether compartments are selectable as a whole only
+          type: boolean
+          default: false
+        status:
+          $ref: '#/components/schemas/AvailabilityStatus'
+        travelClass:
+          $ref: '#/components/schemas/TravelClass'
+        serviceClass:
+          $ref: '#/components/schemas/ServiceClassType'
+
+    PlacePosition:
+      type: object
+      additionalProperties: false
+      description: >-
+        description of a place
+      required:
+        - number
+        - status
+      properties:
+        number:
+          description: >-
+            place number as indicated at the place in the coach
+          type: string
+          nullable: false
+        status:
+          $ref: '#/components/schemas/AvailabilityStatus'
+        isSelectable:
+          description: >-
+            Flag to indicate individual places as non-selectable in
+            case complete compartments must be selected.
+          type: boolean
+          default: true
+        placeProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceProperty'
+
+    AvailabilityStatus:
+      description: >-
+        status of the place or coach
+      type: string
+      enum:
+        - ALLOCATED
+        - FREE
+        - RESTRICTED
+      default: FREE
+
+    SelectedPlace:
+      type: object
+      additionalProperties: false
+      description: >-
+        selected place in case of graphical booking
+      required:
+        - coachNumber
+        - placeNumber
+        - passengerRef
+      properties:
+        coachNumber:
+          type: string
+          nullable: false
+        placeNumber:
+          type: string
+          nullable: false
+        passengerRef:
+          description: >-
+            Id of the passenger
+          type: string
+          nullable: false
+
+    PurchaserResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        purchaser:
+          $ref: '#/components/schemas/Purchaser'
+
+    Purchaser:
+      type: object
+      additionalProperties: false
+      description: >-
+        purchaser information
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          nullable: false
+        externalRef:
+          description: >-
+            A stable reference to a purchaser from other elements, or from caller system. When received in input of a request, it must be echoed back in the response.
+          type: string
+        detail:
+          $ref: '#/components/schemas/PersonDetail'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        companyDetails:
+          $ref: '#/components/schemas/CompanyDetail'
+
+    PurchaserSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal specification of a purchaser to request booking of an offer.
+      required:
+        - detail
+      properties:
+        externalRef:
+          description: >-
+            A stable reference to a purchaser from other elements, or from caller system. When received in input of a request, it must be echoed back in the response.
+          type: string
+        detail:
+          $ref: '#/components/schemas/PersonDetail'
+        companyDetails:
+          $ref: '#/components/schemas/CompanyDetail'
+
+    PassengerResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        passenger:
+          $ref: '#/components/schemas/Passenger'
+
+    Passenger:
+      type: object
+      additionalProperties: false
+      description: >-
+        Information about a passenger.
+        
+        Either the date of birth or the age at the time of travel needs to be set. We recommend to use date of birth as it is more stable than age.
+      required:
+        - id
+        - externalRef
+        - type
+      properties:
+        id:
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the passenger.
+          type: string
+        externalRef:
+          description: >-
+            A stable reference to a passenger from other elements, or from caller system.
+            When passed in passenger specification in an offer request, it must be echoed back in the
+            response.
+          type: string
+          nullable: false
+        dateOfBirth:
+          description: >-
+            date of birth of the passenger
+          type: string
+          format: date
+        type:
+          $ref: '#/components/schemas/PassengerType'
+        cards:
+          description: >-
+            reduction or loyalty cards owned by the passenger
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+        gender:
+          $ref: '#/components/schemas/Gender'
+        detail:
+          $ref: '#/components/schemas/PersonDetail'
+        identificationCard:
+          $ref: '#/components/schemas/IdentificationCard'
+        transportableDetails:
+          $ref: '#/components/schemas/Transportable'
+        prmNeeds:
+          description: >-
+            For the persons with reduced mobility (PRMs) its specific needs for support are expressed.
+          type: array
+          items:
+            $ref: '#/components/schemas/PRMNeedType'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          exclusiveMinimum: true
+
+    AnonymousPassengerSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal specification of a passenger to request offers without any GDPR relevant attributes such as name or address.
+        
+        Either the date of birth or the age at the time of travel needs to be set. We recommend to use date of birth as it is more stable than age.
+      required:
+        - externalRef
+        - type
+      properties:
+        externalRef:
+          description: >-
+            A stable reference to a passenger from other elements, or from caller system. When received in input of a request, it must be echoed back in the response.
+          type: string
+          nullable: false
+          example: TK-id-12345
+        dateOfBirth:
+          description: >-
+            Date of birth of the passenger. Only needed for passengers of type persons, family child, PRM
+            and wheelchair.
+          type: string
+          format: date
+        age:
+          description: >-
+            Age of the passenger  at the date of travel. Less stable than the state of birth.
+          type: integer
+          format: int32
+          minimum: 0
+          exclusiveMinimum: true
+        type:
+          $ref: '#/components/schemas/PassengerType'
+        cards:
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+        prmNeeds:
+          type: array
+          items:
+            $ref: '#/components/schemas/PRMNeedType'
+
+    PassengerSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Minimal specification of a passenger to request offers.
+        
+        Either the date of birth or the age at the time of travel needs to be set. We recommend to use date of birth as it is more stable than age.
+      required:
+        - externalRef
+        - type
+      properties:
+        externalRef:
+          description: >-
+            A stable reference to a passenger from other elements, or from caller system. When received in input of a request, it must be echoed back in the response.
+          type: string
+          nullable: false
+          example: TK-id-12345
+        dateOfBirth:
+          description: >-
+            Date of birth of the passenger. Only needed for passengers of type persons, family child, PRM
+            and wheelchair.
+          type: string
+          format: date
+        age:
+          description: >-
+            Age of the passenger  at the date of travel. Less stable than the state of birth.
+          type: integer
+          format: int32
+          minimum: 0
+          exclusiveMinimum: true
+        cards:
+          description: >-
+            reduction or loyalty cards owned by the passenger
+          type: array
+          items:
+            $ref: '#/components/schemas/CardReference'
+        prmNeeds:
+          description: >-
+            For the persons with reduced mobility (PRMs) its specific needs for support are expressed.
+          type: array
+          items:
+            $ref: '#/components/schemas/PRMNeedType'
+        detail:
+          $ref: '#/components/schemas/PersonDetail'
+        type:
+          $ref: '#/components/schemas/PassengerType'
+
+    PassengerType:
+      description: >-
+        Passenger type according to UIC passenger, i.e. passenger type list.
+        See https://unioninternationalcheminsdefer.github.io/OSDM/spec/catalog-of-code-lists/
+        Proposed default PERSON
+      type: string
+      x-extensible-enum:
+        - DOG
+        - PET
+        - LUGGAGE
+        - PRM
+        - BICYCLE
+        - PRAM
+        - COMPANION_DOG
+        - CAR
+        - PERSON
+        - MOTORCYCLE
+        - TRAILER
+        - FAMILY_CHILD
+        - WHEELCHAIR
+      default: PERSON
+
+    PRMNeedType:
+      type: string
+      x-extensible-enum:
+        - NEED_PRM_SUPPORT
+        - WHEELCHAIR
+        - ACCOMPANYING_DOG
+        - COMPANION_SEAT
+        - COMPANION
+
+    PersonDetail:
+      type: object
+      additionalProperties: false
+      description: >-
+        Personal information potentially needed at booking step. To support privacy by design,
+        it is not permitted to send personal information not required to create a valid booking.
+      required:
+        - firstName
+        - lastName
+      properties:
+        preferredLanguage:
+          description: >-
+            ISO-639-1 language code
+          type: string
+        summary:
+          description: >-
+            A human-readable description of the person.
+          type: string
+        firstName:
+          type: string
+          nullable: false
+        lastName:
+          type: string
+          nullable: false
+        eMail:
+          type: string
+        phoneNumber:
+          description: >-
+            Preferably a mobile phone number, to be contacted in case changes to the booking occur, e.g.,
+            in case of interruptions.
+          type: string
+        address:
+          $ref: '#/components/schemas/Address'
+
+    Gender:
+      description: >-
+        The gender of the passenger, which is important in the case of night trains.
+      type: string
+      enum:
+        - MALE
+        - FEMALE
+        - X
+
+    Transportable:
+      type: object
+      additionalProperties: false
+      description: >-
+        Transportables which are handled similar to passengers like dogs, bicycles, car transport.
+        These transportables might need a ticket or reservation.
+      required:
+        - type
+      properties:
+        type:
+          $ref: '#/components/schemas/TransportableType'
+        car:
+          $ref: '#/components/schemas/Car'
+        motorCycle:
+          $ref: '#/components/schemas/MotorCycle'
+        trailer:
+          $ref: '#/components/schemas/Trailer'
+
+    TransportableType:
+      description: >-
+        Subset of the values from the passenger type code list IRS 90918-10
+      type: string
+      x-extensible-enum:
+        - PET
+        - BICYCLE
+        - CAR
+        - MOTOR_CYCLE
+        - CAR_TRAILER
+
+    Car:
+      type: object
+      additionalProperties: false
+      required:
+        - weight
+        - length
+        - width
+        - height
+        - model
+      properties:
+        weight:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        length:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        width:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        height:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        model:
+          description: >-
+            Free text description of the model (e.g. BMW X5)
+          type: string
+          nullable: false
+        attachedItems:
+          description: >-
+            Indication of items attached to the car
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachableItemType'
+        licensePlate:
+          description: >-
+            The license plate is a personal data item and must not be provided in an offer request.
+            It must be patched into the offer after the customer accepted the offer for booking.
+          type: string
+
+    AttachableItemType:
+      description: >-
+        Indication of items attached to the car
+      type: string
+      x-extensible-enum:
+        - ROOF_RACK
+        - BICYCLE_STAND
+
+    MotorCycle:
+      type: object
+      additionalProperties: false
+      required:
+        - isSideCarIncluded
+      properties:
+        isSideCarIncluded:
+          type: boolean
+          nullable: false
+          default: false
+        licensePlate:
+          description: >-
+            The license plate is a personal data item and must not be provided in an offer request.
+            It must be patched into the offer after the customer accepted the offer for booking
+          type: string
+
+    Trailer:
+      type: object
+      additionalProperties: false
+      required:
+        - weight
+        - length
+        - width
+        - height
+      properties:
+        weight:
+          description: >-
+            weight in kg
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        length:
+          description: >-
+            length in cm
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        width:
+          description: >-
+            width in cm
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        height:
+          description: >-
+            height in cm
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: false
+        licensePlate:
+          description: >-
+            The license plate is a personal data item and must not be provided in an offer request.
+            It must be patched into the offer after the customer accepted the offer for booking
+          type: string
+
+    IdentificationCard:
+      type: object
+      additionalProperties: false
+      description: >-
+        Person identification information  to be exchanged for border control if legally required.
+        
+        It is not allowed to send personal information not required in the offer reply.
+        It is legally not allowed to send these personal data already in the offer request.
+      required:
+        - id
+        - type
+      properties:
+        id:
+          description: >-
+            Identifier on the document.
+          type: string
+          nullable: false
+        type:
+          description: >-
+            Refer to code list for values
+          type: string
+          nullable: false
+        name:
+          description: >-
+            ICAO transliteration identical as written in the document
+          type: string
+        nationality:
+          description: >-
+            ISO 3166 2A codes
+          type: string
+        birthCity:
+          type: string
+        issuingCity:
+          description: >-
+            place where the document is issued
+          type: string
+        residenceCity:
+          type: string
+        birthCountryCode:
+          $ref: '#/components/schemas/CountryCode'
+        issuingCountryCode:
+          $ref: '#/components/schemas/CountryCode'
+        residenceCountryCode:
+          $ref: '#/components/schemas/CountryCode'
+        issuingDate:
+          type: string
+          format: date-time
+        gender:
+          $ref: '#/components/schemas/Gender'
+        expirationDate:
+          type: string
+          format: date
+
+    CardReference:
+      type: object
+      additionalProperties: false
+      required:
+        - types
+        - code
+      properties:
+        types:
+          description: >-
+            Types of card. One card can have multiple roles, such as loyalty and reduction
+          type: array
+          items:
+            $ref: '#/components/schemas/CardType'
+          minItems: 1
+        code:
+          description: >-
+            Code of the card type according to issuer.
+          type: string
+          nullable: false
+        name:
+          description: >-
+            Card name for printing on fulfillments.
+          type: string
+        number:
+          description: >-
+            Unique number identifying the card.
+          type: string
+        issuer:
+          $ref: '#/components/schemas/CompanyRef'
+
+    CardType:
+      description: >-
+        Proposed default REDUCTION_CARD
+      type: string
+      x-extensible-enum:
+        - REDUCTION_CARD
+        - LOYALTY_CARD
+        - CHIP_CARD
+        - PASS
+
+    AncillaryGroup:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - ancillaryRefs
+      properties:
+        id:
+          type: string
+          nullable: false
+        name:
+          type: string
+          nullable: false
+        ancillaryRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferPartReference'
+          minItems: 1
+
+    AncillaryType:
+      type: string
+      x-extensible-enum:
+        - MEAL
+        - BEVERAGE
+
+    BookedOfferAncillaryPatchResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+
+    BookedOfferAncilliaryPatchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - offerId
+        - passengerRefs
+      properties:
+        offerId:
+          description: >-
+            The offerId of the offer containing the offerparts to be added.
+          type: string
+          nullable: false
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+
+    BookedOfferReservationPatchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - offerId
+        - passengerRefs
+        - placeSelections
+      properties:
+        offerId:
+          description: >-
+            The offerId of the offer containing the offerparts to be added.
+          type: string
+          nullable: false
+        passengerRefs:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        tripCoverage:
+          $ref: '#/components/schemas/TripCoverage'
+        placeSelections:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlaceSelection'
+          minItems: 1
+
+    BookedOfferReservationPatchResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        bookedOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookedOffer'
+
+    BookedOfferResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        bookedOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookedOffer'
+
+    BookingResponseContent:
+      description: >-
+        Influences whether referenced resources are returned in full or as references only. 
+      type: string
+      enum:
+        - ALL
+        - BOOKING
+        - BOOKING_PASSENGERS
+        - BOOKING_PURCHASER
+        - BOOKING_TRIPS
+        - BOOKING_BOOKEDOFFERS
+        - BOOKING_FULFILLMENTS
+        - BOOKING_DOCUMENTS
+        - BOOKING_REFUNDOFFERS
+        - BOOKING_RELEASEOFFERS
+        - BOOKING_CANCELFULFILLMENTSOFFER
+        - BOOKING_EXCHANGEOPERATIONS
+        - NONE
+      default: ALL
+
+    BookingSearchParameters:
+      type: object
+      additionalProperties: false
+      properties:
+        numberOfResults:
+          type: integer
+          format: int32
+          default: 10
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookingPartStatus'
+
+    BookingSearchRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        origin:
+          $ref: '#/components/schemas/PlaceRef'
+        destination:
+          $ref: '#/components/schemas/PlaceRef'
+        passenger:
+          $ref: '#/components/schemas/PersonSearchRequest'
+        purchaser:
+          $ref: '#/components/schemas/CompanySearchRequest'
+        bookingId:
+          type: string
+        providerRef:
+          type: string
+        allocatorRef:
+          type: string
+        fulfillmentId:
+          type: string
+        fulfillmentControlNumber:
+          type: string
+        travelDateRange:
+          $ref: '#/components/schemas/DateRange'
+        purchaseDateRange:
+          $ref: '#/components/schemas/DateRange'
+        parameters:
+          $ref: '#/components/schemas/BookingSearchParameters'
+
+    BookingSearchResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        bookingSearchResults:
+          type: array
+          items:
+            $ref: '#/components/schemas/BookingSearchResult'
+
+    BookingSearchResult:
+      type: object
+      additionalProperties: false
+      description: >-
+        Summary of the booking found by the booking search. For more information, get the booking.
+      required:
+        - id
+        - productSummary
+      properties:
+        purchaser:
+          $ref: '#/components/schemas/Purchaser'
+        passengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+        tripSummary:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripSummary'
+        id:
+          type: string
+          nullable: false
+        confirmedPrice:
+          $ref: '#/components/schemas/Price'
+        provisionalPrice:
+          $ref: '#/components/schemas/Price'
+        productSummary:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductSummary'
+          minItems: 1
+
+    CancelFulfillmentsOffer:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - fulfillments
+        - status
+      properties:
+        id:
+          description: >-
+            id of the refund offer
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the refund offer.
+          type: string
+        validUntil:
+          type: string
+          format: date-time
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+          minItems: 1
+        status:
+          $ref: '#/components/schemas/CancelFulfillmentsStatus'
+
+    CancelFulfillmentsOfferCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        cancelFulfillmentOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/CancelFulfillmentsOffer'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    CancelFulfillmentsOfferPatchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/CancelFulfillmentsStatus'
+
+    CancelFulfillmentsOfferRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        fulfillmentIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentId'
+
+    CancelFulfillmentsOfferResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        cancelFulfillmensOffer:
+          $ref: '#/components/schemas/CancelFulfillmentsOffer'
+
+    CoachLayoutGridSize:
+      type: object
+      additionalProperties: false
+      required:
+        - x
+        - y
+      properties:
+        x:
+          type: integer
+          format: int32
+          nullable: false
+        y:
+          type: integer
+          format: int32
+          nullable: false
+
+    CompanyDetail:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - registrationNumber
+        - taxId
+      properties:
+        name:
+          type: string
+          nullable: false
+        registrationNumber:
+          type: string
+          nullable: false
+        legalAddress:
+          $ref: '#/components/schemas/Address'
+        taxId:
+          type: string
+          nullable: false
+
+    CompanySearchRequest:
+      allOf:
+        - $ref: '#/components/schemas/PersonSearchRequest'
+        - type: object
+          additionalProperties: false
+          required:
+            - companyName
+          properties:
+            companyName:
+              type: string
+              nullable: false
+            companyRef:
+              $ref: '#/components/schemas/CompanyRef'
+
+    ContextType:
+      type: string
+      enum:
+        - OFFER
+        - BOOKING
+
+    DateRange:
+      type: object
+      additionalProperties: false
+      properties:
+        startTime:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+
+    Document:
+      type: object
+      additionalProperties: false
+      description: >-
+        Non travel document created. Either downloadLink + downloadExpiry or content + format must be provided.
+      required:
+        - id
+        - type
+        - scope
+      properties:
+        id:
+          type: string
+          nullable: false
+        passengerReference:
+          description: >-
+            Reference to a passenger, to be specified when the document related to an individual passenger.
+          type: string
+        downloadLink:
+          type: string
+          format: uri
+        downloadExpiry:
+          description: >-
+            Expiration time of the download link, the document will not be available at the given URI  after this time.
+          type: string
+          format: date-time
+        content:
+          description: >-
+            base64 encoded binary of the actual fulfillment document
+          type: string
+          format: byte
+        format:
+          description: >-
+            Physical format of the document provided in the content field in Mime-Type format, e.g. application/pdf, image/jpeg, etc. Must be filled if the "content" field is present.
+          type: string
+          example: application/pdf
+        type:
+          $ref: '#/components/schemas/DocumentType'
+        scope:
+          $ref: '#/components/schemas/DocumentScope'
+
+    DocumentCollectionResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - documents
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+          minItems: 1
+
+    DocumentRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - document
+      properties:
+        document:
+          $ref: '#/components/schemas/DocumentSpecification'
+
+    DocumentResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        document:
+          $ref: '#/components/schemas/Document'
+
+    DocumentScope:
+      type: string
+      enum:
+        - BOOKING
+        - PASSENGER
+
+    DocumentSpecification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Non travel document created. Either downloadLink + downloadExpiry or content + format must be provided.
+      required:
+        - scope
+        - type
+      properties:
+        passengerReference:
+          description: >-
+            Reference to a passenger, to be specified when the document related to an individual passenger.
+          type: string
+        content:
+          description: >-
+            base64 encoded binary of the actual fulfillment document
+          type: string
+          format: byte
+        format:
+          description: >-
+            Physical format of the document provided in the content field in Mime-Type format, e.g. application/pdf, image/jpeg, etc. Must be filled if the "content" field is present.
+          type: string
+          example: application/pdf
+        scope:
+          $ref: '#/components/schemas/DocumentScope'
+        type:
+          $ref: '#/components/schemas/DocumentType'
+
+    DocumentType:
+      type: string
+      enum:
+        - BOOKING_RECEIPT
+        - CO2_REPORT
+        - INFORMATION
+        - COMPLAINT_EXPLANATION
+
+    ExchangeOfferCollectionResponseContent:
+      type: string
+      enum:
+        - ALL
+        - EXCHANGEOFFERS
+        - TRIP
+        - PASSENGERS
+        - NONE
+      default: ALL
+
+    ExchangeOperationResponseContent:
+      description: >-
+        Influences whether referenced resources are returned in full or as references only.
+      type: string
+      enum:
+        - ALL
+        - EXCHANGEOPERATION
+        - EXCHANGEOPERATION_EXCHANGEOFFERS
+        - EXCHANGEOPERATION_FULFILLMENTS
+      default: ALL
+
+    ExcludedTimeRange:
+      type: object
+      additionalProperties: false
+      description: >-
+        time ranges excluded from the validity (e.g. off peak fulfillments)
+      required:
+        - from
+        - until
+        - scope
+      properties:
+        from:
+          description: >-
+            minutes of the day in the time zone of travel
+          type: integer
+          format: int32
+          nullable: false
+        until:
+          description: >-
+            minutes of the day in the time zone of travel
+          type: integer
+          format: int32
+          nullable: false
+        scope:
+          $ref: '#/components/schemas/ExclusionScope'
+
+    ExclusionScope:
+      type: string
+      enum:
+        - START_OF_TRAVEL
+        - COMPLETE_RANGE
+
+    FulfillmentActivationPatchRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Changes the fulfillment to status AVAILABLE. In the case of multi-journey  product, one of the fulfillment is
+        now "activated" and can be used to travel.
+      required:
+        - startOfUsage
+      properties:
+        selectedZoneIds:
+          type: array
+          items:
+            type: string
+        travelDates:
+          type: array
+          items:
+            type: string
+            format: date
+        startOfUsage:
+          type: string
+          format: date-time
+          nullable: false
+        fromPlace:
+          $ref: '#/components/schemas/PlaceRef'
+
+    LuggageConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        Constraint on the luggage allowed by a passenger to on board.
+      properties:
+        maxHandLuggage:
+          description: >-
+            standard hand luggage pieces
+          type: integer
+          format: int32
+        maxLargeLuggage:
+          description: >-
+            standard non-hand luggage pieces
+          type: integer
+          format: int32
+        restrictions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LuggageRestriction'
+        restrictionRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/LuggageRestrictionRuleEnum'
+
+    LuggageDimension:
+      type: object
+      additionalProperties: false
+      required:
+        - dimension
+        - value
+      properties:
+        dimension:
+          $ref: '#/components/schemas/LuggageDimensionEnum'
+        value:
+          description: >-
+            Value of the dimension: weight in kg, length in cm, volume in liter.
+          type: string
+          nullable: false
+
+    LuggageDimensionEnum:
+      description: >-
+        Type of the dimension. Combined sizes are the sum of the sizes.
+        
+        Explanation:  WIDTH_HEIGHT_LENGTH = sum of width, hight and length in cm (= linear equivalent).
+        
+      type: string
+      enum:
+        - HEIGHT
+        - LENGTH
+        - WEIGHT
+        - WIDTH
+        - WIDTH_HEIGHT
+        - WIDTH_HEIGHT_LENGTH
+        - VOLUME
+
+    LuggageRestriction:
+      type: object
+      additionalProperties: false
+      required:
+        - dimensionRestrictions
+        - numberOfItems
+      properties:
+        dimensionRestrictions:
+          description: >-
+            The dimension apply to the luggage items as upper limits.
+          type: array
+          items:
+            $ref: '#/components/schemas/LuggageDimension'
+          minItems: 1
+        numberOfItems:
+          description: >-
+            Number of luggage items allowed with this restriction.
+          type: integer
+          format: int32
+          nullable: false
+        registrationIds:
+          description: >-
+            The registrationIds to be included in a bar code on the fulfillment (UIC IRS 90918-4) (e.g. on a luggage tag).
+          type: array
+          items:
+            type: string
+
+    LuggageRestrictionRuleEnum:
+      description: >-
+        Named luggage restriction rule.
+        
+        Valid Values:
+        - CAN_CARRY: Weight is ok if you can carry it yourself.
+      type: string
+      enum:
+        - CAN_CARRY
+
+    NamedCompany:
+      type: object
+      additionalProperties: false
+      description: >-
+        Provides the reference and name of a company.
+      required:
+        - ref
+      properties:
+        ref:
+          $ref: '#/components/schemas/CompanyRef'
+        name:
+          description: >-
+            Textual representation of the carrier to be displayed unless the application is able to indicate the name by the carrier references.
+          type: string
+          example: RhB
+
+    OfferCollectionResponseContent:
+      type: string
+      enum:
+        - ALL
+        - OFFERS
+        - TRIPS
+        - NONE
+      default: ALL
+
+    OfferMode:
+      description: >-
+        Offer Mode applied to provide Offers for given criteria. Distributor may specify which Offer Mode is preferred though the allocator, if not supporting given mode, reverts back to the other mode and provides warning instead. Individual Offer Mode  means that each Passenger is given individual Admissions and Reservations   in order to allow to refund individual Passengers booked in single Booking.
+      type: string
+      enum:
+        - COLLECTIVE
+        - INDIVIDUAL
+
+    OnHoldOffer:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - increasedTTL
+        - onHoldFee
+        - deposit
+      properties:
+        id:
+          type: string
+          nullable: false
+        increasedTTL:
+          description: >-
+            Increased time-to-live.
+          type: string
+          format: date-time
+          nullable: false
+        onHoldFee:
+          $ref: '#/components/schemas/Fee'
+        deposit:
+          $ref: '#/components/schemas/Price'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    OnHoldOfferPatchRequest:
+      type: object
+      additionalProperties: false
+
+    OnHoldOfferRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Confirming the offer puts into the "On-hold" state.
+      required:
+        - increaseTTL
+      properties:
+        increaseTTL:
+          description: >-
+            increase of time to live (in minutes)
+            
+            
+          type: integer
+          format: int32
+          nullable: false
+
+    OnHoldOfferResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        onHoldOffer:
+          $ref: '#/components/schemas/OnHoldOffer'
+
+    PaymentMethod:
+      type: object
+      additionalProperties: false
+      description: >-
+        Method of payment used by the customer to the distributor. On input of voucher the remaining sum attribute is not present.
+      required:
+        - type
+        - voucherInformation
+        - remainingSum
+      properties:
+        type:
+          $ref: '#/components/schemas/PaymentType'
+        voucherInformation:
+          $ref: '#/components/schemas/VoucherInformation'
+        remainingSum:
+          $ref: '#/components/schemas/Price'
+
+    PersonSearchRequest:
+      type: object
+      additionalProperties: false
+      discriminator:
+        propertyName: objectType
+      required:
+        - objectType
+      properties:
+        objectType:
+          description: Attribute is used as discriminator for inheritance between data types.
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        dateOfBirth:
+          type: string
+          format: date
+        phoneNumber:
+          type: string
+        email:
+          type: string
+
+    ProductSummary:
+      type: object
+      additionalProperties: false
+      description: >-
+        Summary of the booking's underlining products.
+      required:
+        - id
+        - description
+        - code
+      properties:
+        id:
+          type: string
+          nullable: false
+        description:
+          type: string
+          nullable: false
+        code:
+          type: string
+          nullable: false
+
+    Quantity:
+      type: object
+      additionalProperties: false
+      description: >-
+        Generic entity to model a quantity.
+      required:
+        - value
+        - unit
+      properties:
+        value:
+          type: number
+          format: float
+          nullable: false
+        unit:
+          type: string
+          nullable: false
+          example: kg
+
+    RefundOfferResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        refundOffer:
+          $ref: '#/components/schemas/RefundOffer'
+
+    RegionalValiditySummary:
+      type: object
+      additionalProperties: false
+      required:
+        - description
+        - shortDescription
+      properties:
+        description:
+          type: string
+          minLength: 1
+          nullable: false
+        shortDescription:
+          type: string
+          minLength: 1
+
+    Reimbursement:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - request
+        - status
+      properties:
+        id:
+          type: string
+          nullable: false
+        request:
+          $ref: '#/components/schemas/ReimbursementRequest'
+        status:
+          $ref: '#/components/schemas/BackOfficeStatus'
+        missingInformation:
+          type: array
+          items:
+            type: string
+        decision:
+          $ref: '#/components/schemas/ReimbursementDecision'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ReimbursementDecision:
+      type: object
+      additionalProperties: false
+      description: >-
+        Decision whether or not the reimbursement is granted. Contains information on the amount reimbursed.
+      properties:
+        amount:
+          $ref: '#/components/schemas/Price'
+        voucher:
+          $ref: '#/components/schemas/FulfillmentDocument'
+        explanation:
+          $ref: '#/components/schemas/SupportingDocument'
+        shortExplanation:
+          type: string
+
+    ReimbursementPatchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - additionalDocuments
+        - updatedStatus
+      properties:
+        additionalDocuments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SupportingDocument'
+          minItems: 1
+        updatedStatus:
+          $ref: '#/components/schemas/BackOfficeStatus'
+
+    ReimbursementReason:
+      description: >-
+        Reason why the booking should be reimbursed.
+      type: string
+      x-extensible-enum:
+        - STRIKE
+        - TICKET_NOT_USED
+
+    ReimbursementRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        The reimbursement process is used to support refunds which are not covered by the online refund/exchange processes, e.g.: Partial refund of a trip (Trip was Hamburg - Munich, but only Hamburg - Kassel was used), Refund outside of rules due to good will. This is a manual back office process within the provider's organization which is triggered by this request. State changes can be signaled by web hook events.
+      required:
+        - reimbursementReason
+        - reimbursedPassengerIds
+        - fulfillmentIds
+      properties:
+        reimbursementReason:
+          $ref: '#/components/schemas/ReimbursementReason'
+        reimbursementDate:
+          type: string
+          format: date-time
+        reimbursedPassengerIds:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        tripSections:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripSection'
+        fulfillmentIds:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          nullable: false
+        supportingDocuments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SupportingDocument'
+
+    ReimbursementResponse:
+      type: object
+      additionalProperties: false
+      description: >-
+        Response to a reimbursement request, containing a state and a decision.
+      required:
+        - reimbursement
+      properties:
+        reimbursement:
+          $ref: '#/components/schemas/Reimbursement'
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+
+    ReleaseOffer:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - status
+        - fulfillments
+      properties:
+        id:
+          description: >-
+            id of the refund offer
+          type: string
+          nullable: false
+        summary:
+          description: >-
+            A human-readable description of the refund offer.
+          type: string
+        validUntil:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/ReleaseStatus'
+        fulfillments:
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+          minItems: 1
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ReleaseOfferCollectionResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        releaseOffers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReleaseOffer'
+        _links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ReleaseOfferPatchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/ReleaseStatus'
+
+    ReleaseOfferRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        fulfillmentIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentId'
+
+    ReleaseOfferResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
+        releaseOffer:
+          $ref: '#/components/schemas/ReleaseOffer'
+
+    ReleaseStatus:
+      type: string
+      enum:
+        - PROPOSED
+        - CONFIRMED
+
+    ReservationGroup:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - reservationRefs
+      properties:
+        id:
+          type: string
+          nullable: false
+        name:
+          type: string
+          nullable: false
+        reservationRefs:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfferPartReference'
+          minItems: 1
+
+    ReservationRelation:
+      type: object
+      additionalProperties: false
+      required:
+        - minGroupItemsToBeBooked
+        - reservationGroup
+      properties:
+        minGroupItemsToBeBooked:
+          type: integer
+          format: int32
+          nullable: false
+        maxGroupItemsToBeBooked:
+          type: integer
+          format: int32
+        reservationGroup:
+          $ref: '#/components/schemas/ReservationGroup'
+
+    ReservationSelection:
+      type: object
+      additionalProperties: false
+      required:
+        - reservationId
+      properties:
+        reservationId:
+          type: string
+          nullable: false
+
+    ResourceType:
+      type: string
+      enum:
+        - FARE
+        - RESERVATION
+
+    ReturnConstraint:
+      type: object
+      additionalProperties: false
+      description: >-
+        a return trip with the same carrier must be sold in combination
+      required:
+        - latestReturn
+        - earliestReturn
+      properties:
+        latestReturn:
+          description: >-
+            number of days after departure or start of validity of the last return
+          type: integer
+          format: int32
+          nullable: false
+        earliestReturn:
+          description: >-
+            number of days after departure or start of validity of the earliest return
+          type: integer
+          format: int32
+          nullable: false
+        excludedWeekdays:
+          description: >-
+            weekdays (ISO day of the week, 1 = Monday) between travel and return where travel is not allowed
+          type: array
+          items:
+            type: integer
+            format: int32
+
+    ServiceAttribute:
+      type: object
+      additionalProperties: false
+      description: >-
+        Facilities of a Service, such as WIFI, Premium. See OSDM master data page for an overview of all service types.
+      required:
+        - code
+        - name
+      properties:
+        code:
+          description: >-
+            Codes from the service facilities code list
+          type: string
+          nullable: false
+        name:
+          type: string
+          nullable: false
+
+    StopBehavior:
+      type: string
+      enum:
+        - ORIGIN_DESTINATION_ONLY
+        - REAL_BOARDING_ALIGHTING
+
+    ThroughTicketTag:
+      description: >-
+        Known Values:
+        - RESPLUS: Through ticket tag according to Swedish Regulation.
+      type: string
+      x-extensible-enum:
+        - RESPLUS
+
+    TimeUnit:
+      type: string
+      enum:
+        - DAYS
+        - HOURS
+        - MINUTES
+
+    TripCoverage:
+      type: object
+      additionalProperties: false
+      required:
+        - coveredTripId
+      properties:
+        coveredTripId:
+          type: string
+          nullable: false
+        coveredLegIds:
+          description: >-
+            Indicate which legs are covered by the specific offer. Not used for fares.
+          type: array
+          items:
+            type: string
+        coveredSections:
+          type: array
+          items:
+            $ref: '#/components/schemas/Section'
+
+    TripDirectionType:
+      type: string
+      enum:
+        - OUT_BOUND
+        - IN_BOUND
+      default: OUT_BOUND
+
+    TripLegCoverage:
+      type: object
+      additionalProperties: false
+      required:
+        - tripId
+        - legId
+      properties:
+        tripId:
+          type: string
+          nullable: false
+        legId:
+          type: string
+          nullable: false
+
+    TripResponseContent:
+      type: string
+      enum:
+        - ALL
+        - PLACES
+        - NONE
+      default: ALL
+
+    TripSection:
+      type: object
+      additionalProperties: false
+      description: >-
+        Part of a trip.
+      required:
+        - tripId
+      properties:
+        tripId:
+          type: string
+          nullable: false
+        coveredSection:
+          $ref: '#/components/schemas/Section'
+
+    TripsCollectionResponseContent:
+      type: string
+      enum:
+        - ALL
+        - TRIPS
+        - TRIPSUMMARIES
+        - NONE
+      default: ALL
+
+    ValidityRange:
+      type: object
+      additionalProperties: false
+      required:
+        - timeUnit
+        - value
+      properties:
+        timeUnit:
+          $ref: '#/components/schemas/TimeUnit'
+        value:
+          type: integer
+          format: int32
+          nullable: false
+        hoursAfterMidnight:
+          description: >-
+            validity extended after midnight
+          type: integer
+          format: int32
+
+    ValidityType:
+      description: >-
+        Type of usage, either as single trip or multiple trips. Unrestricted fares might be combined 
+        into single trips if appropriate.
+      type: string
+      x-extensible-enum:
+        - SINGLE_TRIP
+        - MULTIPLE_TRIPS
+        - UNRESTRICTED
+
+    VoucherInformation:
+      type: object
+      additionalProperties: false
+      required:
+        - issuer
+        - code
+      properties:
+        issuer:
+          $ref: '#/components/schemas/CompanyRef'
+        code:
+          description: >-
+            voucher code provided by the issuer
+          type: string
+          nullable: false
+


### PR DESCRIPTION
Version 2.0.1 contains the following changes:
- TripCoverage.coveredLegIds is now nullable
- OfferCollectionRequest.tripIds is now nullable
- TripCoverage.coveredLegIds is now nullable
- Changes data type of Longitude and Latitude from float to double. This solves precision issues and esnures compatibility with Java's Bean Validation mechanism
- Minor changes to some comments