### PR TITLE
WIP: I-72.1 FulfillmentParts for Offer #320

### DIFF
--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -8084,6 +8084,7 @@ components:
       type: string
       x-extensible-enum:
         - "ALLOCATOR_APP"
+        - "FULFILLMENT_PARTS"
         - "PDF_A4"
         - "PKPASS"
         - "RCCST"


### PR DESCRIPTION
We have separated issues from I-72.

This `FulfillmentMediaType` allows to provide FulfillmentParts inside Fulfillment. Those are normally available to Booked Fare only, but some distributors of Offer may need that as well. Those information are used to populate ticket/receipt generated on the distributor side.

Example: Deutsche Bahn and Deutsche Lufthansa for Bahn&Flug.