### PR TITLE
412 mapping back from bookingparts to offerparts

### DIFF
--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -4403,6 +4403,10 @@ components:
         id:
           type: string
           nullable: false
+        externalRef:
+          description: If an externalRef was given in the Booking request or BookedOfferRequest, it must be returned here
+          type: string
+          nullable: false
         summary:
           type: string
           nullable: true
@@ -4872,6 +4876,21 @@ components:
               items:
                 $ref: '#/components/schemas/RegulatoryCondition'
 
+    AdmissionOfferMapping:
+      type: object
+      additionalProperties: false
+      required:
+        - admissionId
+        - externalRef
+      properties:
+        admissionId:
+          description: OfferPartId of the admission
+          type: string
+          nullable: false
+        externalRef:
+          type: string
+          nullable: false
+
     AdmissionOfferPart:
       description: |
         An admission represents a travel right, or the entitlement to travel onboard a train between
@@ -5089,6 +5108,9 @@ components:
         - passengerRefs
       properties:
         ancillaryId:
+          type: string
+          nullable: false
+        externalRef:
           type: string
           nullable: false
         passengerRefs:
@@ -5436,6 +5458,9 @@ components:
         ancillaryOfferId:
           type: string
           nullable: false
+        externalRef:
+          type: string
+          nullable: false
         passengerRefs:
           type: array
           items:
@@ -5498,6 +5523,9 @@ components:
           type: string
           nullable: false
         reservationOfferId:
+          type: string
+          nullable: false
+        externalRef:
           type: string
           nullable: false
         passengerRefs:
@@ -7841,6 +7869,21 @@ components:
           description: |
             Reference to the Product representing the Fee
 
+    FeeOfferMapping:
+      type: object
+      additionalProperties: false
+      required:
+        - feeId
+        - externalRef
+      properties:
+        feeId:
+          description: OfferPartId of the fee
+          type: string
+          nullable: false
+        externalRef:
+          type: string
+          nullable: false
+
     Flexibility:
       type: string
       x-extensible-enum:
@@ -8381,6 +8424,20 @@ components:
         - "JOURNEY_ABANDONED"
         - "JOURNEY_NOT_STARTED"
         - "SERVICE_DEGRADED"
+
+    ImplicitReservationOfferMapping:
+      type: object
+      additionalProperties: false
+      required:
+        - reservationId
+      properties:
+        reservationId:
+          description: OfferPartId of the (included or mandatory) reservation
+          type: string
+          nullable: false
+        externalRef:
+          type: string
+          nullable: false
 
     IndicatedConsumption:
       type: object
@@ -9339,6 +9396,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AncillarySelection'
+        admissionOfferMappings:
+          description: |
+            This contains a mapping from the offer part id to an external ref for AdmissionOfferParts.
+          type: array
+          items:
+            $ref: '#/components/schemas/AdmissionOfferMapping'
+        implicitReservationOfferMappings:
+          description: |
+            This contains a mapping from the offer part id to an external ref for implicitly booked reservations (included reservations and mandatory reservations).
+          type: array
+          items:
+            $ref: '#/components/schemas/ImplicitReservationsOfferMapping'
+        feeOfferMappings:
+          description: |
+            This contains a mapping from the offer part id to an external ref for fees.
+          type: array
+          items:
+            $ref: '#/components/schemas/FeeOfferMapping'
         placeSelections:
           type: array
           items:
@@ -11431,6 +11506,9 @@ components:
         - reservationId
       properties:
         reservationId:
+          type: string
+          nullable: false
+        externalRef:
           type: string
           nullable: false
 

--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -7869,21 +7869,6 @@ components:
           description: |
             Reference to the Product representing the Fee
 
-    FeeOfferMapping:
-      type: object
-      additionalProperties: false
-      required:
-        - feeId
-        - externalRef
-      properties:
-        feeId:
-          description: OfferPartId of the fee
-          type: string
-          nullable: false
-        externalRef:
-          type: string
-          nullable: false
-
     Flexibility:
       type: string
       x-extensible-enum:
@@ -8430,6 +8415,7 @@ components:
       additionalProperties: false
       required:
         - reservationId
+        - externalRef
       properties:
         reservationId:
           description: OfferPartId of the (included or mandatory) reservation
@@ -9408,12 +9394,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ImplicitReservationOfferMapping'
-        feeOfferMappings:
-          description: |
-            This contains a mapping from the offer part id to an external ref for fees.
-          type: array
-          items:
-            $ref: '#/components/schemas/FeeOfferMapping'
         placeSelections:
           type: array
           items:

--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -9407,7 +9407,7 @@ components:
             This contains a mapping from the offer part id to an external ref for implicitly booked reservations (included reservations and mandatory reservations).
           type: array
           items:
-            $ref: '#/components/schemas/ImplicitReservationsOfferMapping'
+            $ref: '#/components/schemas/ImplicitReservationOfferMapping'
         feeOfferMappings:
           description: |
             This contains a mapping from the offer part id to an external ref for fees.


### PR DESCRIPTION
Added externalRefs to the booking requests. This affects these endpoints:
POST /bookings
POST /bookings/{bookingId}/booked-offers/{bookedOfferId}/reservations
POST /bookings/{bookingId}/booked-offers/{bookedOfferId}/ancilliaries
POST /bookings/{bookingId}/booked-offers

and any responses that return a Booking.
