### PR TITLE
408 need single soldproductid on offer parts

### DIFF
--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -4515,6 +4515,9 @@ components:
           description: Amount to be refunded to the purchaser
         tripCoverage:
           $ref: '#/components/schemas/TripCoverage'
+        summaryProductId:
+          type: string
+          description: Id of the product representing the commercial attributes of this booking part
         products:
           description: |
             In offer mode, in almost all cases exactly one product is referenced. Only on some French

--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -4709,6 +4709,9 @@ components:
           $ref: '#/components/schemas/OfferTag'
         requestedInformation:
           $ref: '#/components/schemas/RequestedInformation'
+        summaryProductId:
+          type: string
+          description: Id of the product representing the commercial attributes of this offer part
         products:
           type: array
           items:


### PR DESCRIPTION
Added the summaryProductId to both the AbstractOfferPart and the AbstractBookingPart.