### PR TITLE
412 mapping back from bookingparts to offerparts 2

### DIFF
--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -4472,12 +4472,6 @@ components:
         id:
           type: string
           nullable: false
-        externalRef:
-          description: |
-            If an externalRef was given in the Booking request or
-            BookedOfferRequest, it must be returned here.
-          type: string
-          nullable: false
         summary:
           type: string
           nullable: true
@@ -5057,21 +5051,6 @@ components:
               items:
                 $ref: '#/components/schemas/RegulatoryCondition'
 
-    AdmissionOfferMapping:
-      type: object
-      additionalProperties: false
-      required:
-        - admissionId
-        - externalRef
-      properties:
-        admissionId:
-          description: OfferPartId of the admission
-          type: string
-          nullable: false
-        externalRef:
-          type: string
-          nullable: false
-
     AdmissionOfferPart:
       description: |
         An admission represents a travel right, or the entitlement to travel onboard a train between
@@ -5289,9 +5268,6 @@ components:
         - passengerRefs
       properties:
         ancillaryId:
-          type: string
-          nullable: false
-        externalRef:
           type: string
           nullable: false
         passengerRefs:
@@ -5675,9 +5651,6 @@ components:
         ancillaryOfferId:
           type: string
           nullable: false
-        externalRef:
-          type: string
-          nullable: false
         passengerRefs:
           type: array
           items:
@@ -5742,9 +5715,6 @@ components:
           type: string
           nullable: false
         reservationOfferId:
-          type: string
-          nullable: false
-        externalRef:
           type: string
           nullable: false
         passengerRefs:
@@ -8668,21 +8638,6 @@ components:
         - 'JOURNEY_NOT_STARTED'
         - 'SERVICE_DEGRADED'
 
-    ImplicitReservationOfferMapping:
-      type: object
-      additionalProperties: false
-      required:
-        - reservationId
-        - externalRef
-      properties:
-        reservationId:
-          description: OfferPartId of the (included or mandatory) reservation
-          type: string
-          nullable: false
-        externalRef:
-          type: string
-          nullable: false
-
     IndicatedConsumption:
       type: object
       additionalProperties: false
@@ -9640,18 +9595,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AncillarySelection'
-        admissionOfferMappings:
-          description: |
-            This contains a mapping from the offer part id to an external ref for AdmissionOfferParts.
-          type: array
-          items:
-            $ref: '#/components/schemas/AdmissionOfferMapping'
-        implicitReservationOfferMappings:
-          description: |
-            This contains a mapping from the offer part id to an external ref for implicitly booked reservations (included reservations and mandatory reservations).
-          type: array
-          items:
-            $ref: '#/components/schemas/ImplicitReservationOfferMapping'
         placeSelections:
           type: array
           items:
@@ -11785,9 +11728,6 @@ components:
         - reservationId
       properties:
         reservationId:
-          type: string
-          nullable: false
-        externalRef:
           type: string
           nullable: false
 

--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -13051,12 +13051,24 @@ components:
         If neither coveredLegIds nor coveredSections are defined, the complete trip is covered.
         coveredLegIds and coveredSections are mutually exclusive, i.e. only one of the structures can be present.
 
+        If either coveredLegIds or coveredSections is defined, the sectionIndex field must be filled to indicate which part of the trip is covered
+        by the respective OfferPart or BookingPart
+
       required:
         - coveredTripId
       properties:
         coveredTripId:
           type: string
           nullable: false
+        sectionIndex:
+          description: |
+            Describes which part of the trip (in order) is covered by the OfferPart/BookingPart which contains this TripCoverage structure.
+
+            This needs to be filled if either coveredLegIds or coveredSections is present.
+          type: integer
+          format: int32
+          minimum: 1
+          nullable: true
         coveredLegIds:
           description: |
             Indicate which legs are covered by the specific offer. Not used for fares.

--- a/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
+++ b/specification/v3.2/OSDM-online-api-v3.2.0_draft.yml
@@ -4511,7 +4511,10 @@ components:
           $ref: '#/components/schemas/TripCoverage'
         summaryProductId:
           type: string
-          description: Id of the product representing the commercial attributes of this booking part
+          description: |
+            Id of the product representing the commercial attributes of this booking part. Although not currently
+            mandatory, this attribute should in all cases be filled in order to allow matching a booking response
+            to the data in the booking request
         products:
           description: |
             In offer mode, in almost all cases exactly one product is referenced. Only on some French
@@ -4708,7 +4711,8 @@ components:
           $ref: '#/components/schemas/RequestedInformation'
         summaryProductId:
           type: string
-          description: Id of the product representing the commercial attributes of this offer part
+          description: Id of the product representing the commercial attributes of this offer part. Although not currently
+            mandatory, this attribute should in all cases be facilitate product based processing at the client
         products:
           type: array
           items:
@@ -5601,6 +5605,7 @@ components:
         offerId:
           type: string
           nullable: false
+          description: Note that the offerId returned does not necessarily match the offerId given in the Booking Request.
         summary:
           description: |
             A human-readable description of the booked offer.


### PR DESCRIPTION
Resolving Issue #412:

- Revert previous changes
- Add sectionIndex to TripCoverage
- Add documentation to indicate that summaryProductId should always be filled
- Add documentation to indicate that the offerId is not stable.