### PR TITLE
#742 Admission(OfferPart) regionalValidity

### DIFF
--- a/specification/v3.4/OSDM-online-api-v3.4.1.yml
+++ b/specification/v3.4/OSDM-online-api-v3.4.1.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: UIC 90918-10 - OSDM
-  version: 4.0.0-draft
+  version: 3.4.1
   description: |
     Specifications for the OSDM API standard. The OSDM specification supports two modes of operation: Retailer Mode and Distributor Mode. The API works identically in both modes, except that in distributor mode the API also returns fare information.
 
@@ -108,6 +108,8 @@ paths:
       operationId: getPlaces
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/ifNoneMatch'
@@ -170,6 +172,8 @@ paths:
       operationId: postPlaces
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -218,6 +222,8 @@ paths:
       operationId: getPlacesId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -390,7 +396,9 @@ paths:
     post:
       tags:
         - Trips
-      summary: Returns a new trip for given OJP parameters based on an already existing trip
+      summary:
+        Returns a new trip for given OJP parameters based on an already existing
+        trip
       description: |
         Returns a new trip for given OJP parameters based on an already existing trip.
       operationId: postTripsChange
@@ -414,7 +422,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TripResponse'
-
         '400':
           $ref: '#/components/responses/BadRequestResponse'
         '401':
@@ -569,7 +576,10 @@ paths:
     get:
       tags:
         - Offers
-      summary: Get additional offers of booked offer for a given booking. A provider can decide to allow or reject additional offers admissions, reservations or ancillaries on an confirmed booking.
+      summary:
+        Get additional offers of booked offer for a given booking. A provider
+        can decide to allow or reject additional offers admissions, reservations
+        or ancillaries on an confirmed booking.
       operationId: getBookingBookedOffersAdditionalOffers
       parameters:
         - $ref: '#/components/parameters/requestor'
@@ -874,7 +884,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PassengerSpecification'
+              $ref: '#/components/schemas/Passenger'
       responses:
         '200':
           description: |
@@ -987,7 +997,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PurchaserSpecification'
+              $ref: '#/components/schemas/Purchaser'
       responses:
         '200':
           description: |
@@ -1025,6 +1035,7 @@ paths:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         'default':
           $ref: '#/components/responses/DefaultErrorResponse'
+
     post:
       tags:
         - Purchaser
@@ -1062,6 +1073,7 @@ paths:
                 type: string
                 description: |
                   The language of translatable strings in the response (see RFC2616-sec14.12).
+
         '400':
           $ref: '#/components/responses/BadRequestResponse'
         '401':
@@ -1208,6 +1220,8 @@ paths:
       operationId: deleteBookingBookedOffersId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1258,6 +1272,8 @@ paths:
       operationId: deleteBookingBookedOffersIdPassengerId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1307,7 +1323,10 @@ paths:
     post:
       tags:
         - BookingPart
-      summary: Adds a reservation to a booking. A provider can decide to allow or reject additional admissions, reservations or ancillaries on an confirmed booking.
+      summary:
+        Adds a reservation to a booking. A provider can decide to allow or
+        reject additional admissions, reservations or ancillaries on an
+        confirmed booking.
       operationId: createBookingBookedOffersReservations
       parameters:
         - $ref: '#/components/parameters/requestor'
@@ -1371,10 +1390,14 @@ paths:
     delete:
       tags:
         - BookingPart
-      summary: Removes a reservation from a booking in case the reservation was not yet confirmed. On confirmed reservations use the refund.
+      summary:
+        Removes a reservation from a booking in case the reservation was not yet
+        confirmed. On confirmed reservations use the refund.
       operationId: deleteBookingBookedOffersReservations
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1425,7 +1448,10 @@ paths:
     post:
       tags:
         - BookingPart
-      summary: Adds an ancillary to a booking. A provider can decide to allow or reject additional admissions, reservations or ancillaries on an confirmed booking.
+      summary:
+        Adds an ancillary to a booking. A provider can decide to allow or reject
+        additional admissions, reservations or ancillaries on an confirmed
+        booking.
       operationId: createBookingBookedOffersAncillaries
       parameters:
         - $ref: '#/components/parameters/requestor'
@@ -1489,10 +1515,14 @@ paths:
     delete:
       tags:
         - BookingPart
-      summary: Removes an ancillary from a booking in case the ancillary is not jet confirmed. On confirmed ancillaries use the refund.
+      summary:
+        Removes an ancillary from a booking in case the ancillary is not jet
+        confirmed. On confirmed ancillaries use the refund.
       operationId: deleteBookingBookedOffersAncillary
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1543,7 +1573,9 @@ paths:
     delete:
       tags:
         - BookingPart
-      summary: Removes an admission from a booking. In case the admission is not confirmed. On a confirmed admission use the refund.
+      summary:
+        Removes an admission from a booking. In case the admission is not
+        confirmed. On a confirmed admission use the refund.
       description: |
         Removes an admission from pre-booked booking.It is up to the provider
         to change or remove dependent bookedOfferParts or to reject the request.
@@ -1551,6 +1583,8 @@ paths:
       operationId: deleteBookingBookedOffersAdmission
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1786,6 +1820,8 @@ paths:
       operationId: deleteBookingsId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -1986,6 +2022,8 @@ paths:
       operationId: splitBookings
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/idempotencyKey'
@@ -2103,7 +2141,7 @@ paths:
       summary: Optionally finalizes the fulfillments in asynchronous mode.
       description: |
         Optionally finalizes the fulfillment in case of an asynchronous fulfillment mode when the provider doesn't complete the asynchronous fulfillment automatically.
-        
+
         This step may be used as an indication of the `proof of delivery` to disallow the cancellation of booking.
       operationId: finalizeFulfillments
       parameters:
@@ -2472,6 +2510,8 @@ paths:
       operationId: deleteRefundOffers
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -2955,6 +2995,8 @@ paths:
       operationId: deleteCancelFulfillmentOffers
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -3270,6 +3312,8 @@ paths:
       operationId: deleteBookingsExchangeOperation
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: bookingId
@@ -3332,7 +3376,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ComplaintRequest'
+              $ref: '#/components/schemas/Complaint'
       responses:
         '200':
           description: |
@@ -3487,6 +3531,8 @@ paths:
       operationId: getCoachLayouts
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: page
@@ -3539,6 +3585,8 @@ paths:
       operationId: getCoachLayoutsLayoutId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: layoutId
@@ -3584,16 +3632,18 @@ paths:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         'default':
           $ref: '#/components/responses/DefaultErrorResponse'
-  /reduction-card-types:
+  /reduction-cards:
     get:
       tags:
         - Master Data
       summary: Returns all reduction card definitions.
       description: |
         returns a collection of reduction card definitions
-      operationId: getReductionCardTypes
+      operationId: getReductionCards
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -3608,7 +3658,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReductionCardTypeCollectionResponse'
+                $ref: '#/components/schemas/ReductionCardCollectionResponse'
           headers:
             Cache-Control:
               schema:
@@ -3650,6 +3700,8 @@ paths:
       operationId: getZones
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -4117,6 +4169,74 @@ paths:
         'default':
           $ref: '#/components/responses/DefaultErrorResponse'
   /availabilities/place-map:
+    get:
+      tags:
+        - Availabilities
+      summary: Get place map including availabilities.
+      description: |
+        Get place map including availabilities.
+      operationId: getAvailabilitiesPlaceMap
+      parameters:
+        - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+        - $ref: '#/components/parameters/traceParent'
+        - $ref: '#/components/parameters/traceState'
+        - name: contextId
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 32768
+        - name: contextType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ContextType'
+        - name: resourceId
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 32768
+        - name: resourceType
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/ResourceType'
+      responses:
+        '200':
+          description: |
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlaceAvailabilityResponse'
+          headers:
+            Content-Language:
+              schema:
+                type: string
+                description: |
+                  The language of translatable strings in the response (see RFC2616-sec14.12).
+
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '406':
+          $ref: '#/components/responses/NotAcceptableResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerErrorResponse'
+        '501':
+          $ref: '#/components/responses/NotImplementedResponse'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        'default':
+          $ref: '#/components/responses/DefaultErrorResponse'
     post:
       tags:
         - Availabilities
@@ -4142,7 +4262,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlaceAvailabilitiesResponse'
+                type: array
+                maxItems: 50
+                items:
+                  $ref: '#/components/schemas/PlaceAvailability'
           headers:
             Content-Language:
               schema:
@@ -4180,6 +4303,8 @@ paths:
       operationId: getAvailabilitiesNearby
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: contextId
@@ -4267,6 +4392,8 @@ paths:
       operationId: getAvailabilitiesPreferences
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - name: contextId
@@ -4334,6 +4461,8 @@ paths:
       operationId: getProducts
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -4341,6 +4470,30 @@ paths:
           in: query
           schema:
             type: string
+        - name: productCode
+          in: query
+          description: the product code
+          schema:
+            type: string
+        - name: issuingDate
+          in: query
+          description:
+            To be used in combination with a productCode. Is the issuing date to
+            take into account for product definition. If none is provided, today
+            is assumed.
+          schema:
+            type: string
+            format: date
+        - name: travelDate
+          description:
+            To be used in combination with a productCode. Is the travel date to
+            take into account for product definition. If none is provided, today
+            is assumed.
+          in: query
+          schema:
+            type: string
+            format: date
+
       responses:
         '200':
           description: |
@@ -4390,6 +4543,8 @@ paths:
       operationId: getProductsId
       parameters:
         - $ref: '#/components/parameters/requestor'
+        - $ref: '#/components/parameters/acceptLanguage'
+          description: deprecated
         - $ref: '#/components/parameters/traceParent'
         - $ref: '#/components/parameters/traceState'
         - $ref: '#/components/parameters/acceptNamespace'
@@ -4519,7 +4674,9 @@ components:
       name: x-accept-namespace
       in: header
       description:
-        The x-accept-namespace HTTP header indicates the URN namespace that the client prefers. The provider uses content-negotiation to apply the corresponding namespace(s) where applicable.
+        The x-accept-namespace HTTP header indicates the URN namespace that the
+        client prefers. The provider uses content-negotiation to apply the
+        corresponding namespace(s) where applicable.
       example: x_swe, uic, iata
       schema:
         type: string
@@ -4558,7 +4715,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemCollection'
+            $ref: '#/components/schemas/WarningCollection'
 
     ConflictResponse:
       description: |
@@ -4590,7 +4747,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ProblemCollection'
+            $ref: '#/components/schemas/WarningCollection'
 
     InternalServerErrorResponse:
       description: |
@@ -4683,6 +4840,15 @@ components:
           type: string
           format: date-time
           nullable: false
+        confirmableUntil:
+          deprecated: true
+          description: |
+            confirmationTimeLimit in booking should be used.
+            Date until the booking part needs to be confirmed. Must be provided for a booking part in PREBOOKED stated.
+            For later states, the value is ignored and can be null.
+          type: string
+          format: date-time
+          nullable: false
         validFrom:
           type: string
           format: date-time
@@ -4703,7 +4869,9 @@ components:
           $ref: '#/components/schemas/Price'
         refundAmount:
           $ref: '#/components/schemas/Price'
-          description: Amount refunded or to be refunded to the purchaser depending on the product conditions and status of the booking Part
+          description:
+            Amount refunded or to be refunded to the purchaser depending on the
+            product conditions and status of the booking Part
         tripCoverage:
           $ref: '#/components/schemas/TripCoverage'
         summaryProductId:
@@ -4728,6 +4896,18 @@ components:
           type: string
           description: |
             The unique booking code for the part in the provider system.
+        distributorBookingRef:
+          description: |
+            reference to the booking in the downstream distributor system
+          type: string
+          nullable: true
+          deprecated: true
+        retailerBookingRef:
+          description: |
+            reference to the booking in the downstream distributor system
+          type: string
+          nullable: true
+          deprecated: true
         passengerIds:
           description: |
             Id of the passenger
@@ -4751,7 +4931,7 @@ components:
           items:
             $ref: '#/components/schemas/AfterSaleCondition'
         afterSalesOverrideDetails:
-            $ref: '#/components/schemas/AfterSalesOverrideDetails'
+          $ref: '#/components/schemas/AfterSalesOverrideDetails'
         appliedCorporateCodes:
           type: array
           items:
@@ -4901,8 +5081,10 @@ components:
           $ref: '#/components/schemas/RequestedInformation'
         summaryProductId:
           type: string
-          description: Id of the product representing the commercial attributes of this offer part. Although not currently
-            mandatory, this attribute should in all cases be facilitate product based processing at the client
+          description:
+            Id of the product representing the commercial attributes of this
+            offer part. Although not currently mandatory, this attribute should
+            in all cases be facilitate product based processing at the client
         products:
           type: array
           items:
@@ -4925,6 +5107,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PromotionCode'
+        appliedReductionCardTypes:
+          deprecated: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ReductionCardType'
         regionalValiditySummary:
           $ref: '#/components/schemas/RegionalValiditySummary'
         indicatedConsumption:
@@ -4994,98 +5181,98 @@ components:
       default: 'ANY_SEAT'
       nullable: false
       x-extensible-enum:
-        - "AISLE"
-        - "AIR-CONDITIONED"
-        - "ANY_SEAT"
-        - "BISTRO"
-        - "BICYCLE"
-        - "BUSINESS"
-        - "BUSINESS_COMFORT"
-        - "CABIN8"
-        - "CAR_SMALL"
-        - "CAR_LARGE"
-        - "CARRE"
-        - "CHILDREN_AREA"
-        - "CLUB"
-        - "CLUB_2"
-        - "CLUB_4"
-        - "COMPARTMENT"
-        - "COMPLETE"
-        - "CONFERENCE"
-        - "CONNECTING_DOOR"
-        - "COUCHETTE_2"
-        - "COUCHETTE_4"
-        - "COUCHETTE_5"
-        - "COUCHETTE_6"
-        - "COUCHETTE_COMFORT_4"
-        - "COUCHETTE_COMFORT_5"
-        - "COUCHETTE_COMFORT_6"
-        - "COUCHETTE_PRM_2"
-        - "COUCHETTE_PRM_3"
-        - "COUCHETTE_PRM_4"
-        - "DOUBLE"
-        - "DOUBLE_SWC"
-        - "DOUBLE_SWC_DB"
-        - "DOUBLE_S"
-        - "EASY_ACCESS"
-        - "FACE_2_FACE"
-        - "EXCELLENCE"
-        - "FAMILY"
-        - "FRONT_VIEW"
-        - "HISTORIC_COACH"
-        - "INCLUDING_MEAL"
-        - "INCLUDING_DRINK"
-        - "KIOSQUE"
-        - "LADIES"
-        - "LOWER_BED"
-        - "LOWER_DECK"
-        - "MEN"
-        - "MIDDLE_BED"
-        - "MIDDLE_SEAT"
-        - "MINI_SUITE"
-        - "MIXED"
-        - "MOTOR_CYCLE"
-        - "MOTOR_CYCLE_SC"
-        - "NEAR_ANIMALS"
-        - "NEAR_DINING"
-        - "NEAR_PLAY_AREA"
-        - "NEAR_BICYCLE_AREA"
-        - "NEAR_WHEELCHAIR"
-        - "OPEN_SPACE"
-        - "PANORAMA"
-        - "PHONE"
-        - "POWER"
-        - "PRAM"
-        - "PRAM_WITH_SEAT"
-        - "RESTAURANT"
-        - "SILENCE"
-        - "SINGLE"
-        - "SINGLE_SWC"
-        - "SINGLE_SWC_DOUBLE"
-        - "SIDE_BY_SIDE"
-        - "SALON"
-        - "SLEEPERETTE"
-        - "SLEEPER_DELUXE"
-        - "SOLO"
-        - "SOLO_COM"
-        - "SPECIAL_SLEEPER"
-        - "TABLE"
-        - "TANDEM"
-        - "TOURIST_SLEEPER_2"
-        - "TOURIST_SLEEPER_3"
-        - "TOURIST_SLEEPER_4"
-        - "TOURIST_SLEEPER_3_SWC"
-        - "UPPER_BED"
-        - "UPPER_DECK"
-        - "VIDEO"
-        - "WHEELCHAIR"
-        - "WHEELCHAIR_AND_SEAT"
-        - "WHEELCHAIR_NO_SEAT"
-        - "WIFI"
-        - "WINDOW"
-        - "WITH_ANIMALS"
-        - "WITH_SMALL_CHILDREN"
-        - "WITHOUT_ANIMALS"
+        - 'AISLE'
+        - 'AIR-CONDITIONED'
+        - 'ANY_SEAT'
+        - 'BISTRO'
+        - 'BICYCLE'
+        - 'BUSINESS'
+        - 'BUSINESS_COMFORT'
+        - 'CABIN8'
+        - 'CAR_SMALL'
+        - 'CAR_LARGE'
+        - 'CARRE'
+        - 'CHILDREN_AREA'
+        - 'CLUB'
+        - 'CLUB_2'
+        - 'CLUB_4'
+        - 'COMPARTMENT'
+        - 'COMPLETE'
+        - 'CONFERENCE'
+        - 'CONNECTING_DOOR'
+        - 'COUCHETTE_2'
+        - 'COUCHETTE_4'
+        - 'COUCHETTE_5'
+        - 'COUCHETTE_6'
+        - 'COUCHETTE_COMFORT_4'
+        - 'COUCHETTE_COMFORT_5'
+        - 'COUCHETTE_COMFORT_6'
+        - 'COUCHETTE_PRM_2'
+        - 'COUCHETTE_PRM_3'
+        - 'COUCHETTE_PRM_4'
+        - 'DOUBLE'
+        - 'DOUBLE_SWC'
+        - 'DOUBLE_SWC_DB'
+        - 'DOUBLE_S'
+        - 'EASY_ACCESS'
+        - 'FACE_2_FACE'
+        - 'EXCELLENCE'
+        - 'FAMILY'
+        - 'FRONT_VIEW'
+        - 'HISTORIC_COACH'
+        - 'INCLUDING_MEAL'
+        - 'INCLUDING_DRINK'
+        - 'KIOSQUE'
+        - 'LADIES'
+        - 'LOWER_BED'
+        - 'LOWER_DECK'
+        - 'MEN'
+        - 'MIDDLE_BED'
+        - 'MIDDLE_SEAT'
+        - 'MINI_SUITE'
+        - 'MIXED'
+        - 'MOTOR_CYCLE'
+        - 'MOTOR_CYCLE_SC'
+        - 'NEAR_ANIMALS'
+        - 'NEAR_DINING'
+        - 'NEAR_PLAY_AREA'
+        - 'NEAR_BICYCLE_AREA'
+        - 'NEAR_WHEELCHAIR'
+        - 'OPEN_SPACE'
+        - 'PANORAMA'
+        - 'PHONE'
+        - 'POWER'
+        - 'PRAM'
+        - 'PRAM_WITH_SEAT'
+        - 'RESTAURANT'
+        - 'SILENCE'
+        - 'SINGLE'
+        - 'SINGLE_SWC'
+        - 'SINGLE_SWC_DOUBLE'
+        - 'SIDE_BY_SIDE'
+        - 'SALON'
+        - 'SLEEPERETTE'
+        - 'SLEEPER_DELUXE'
+        - 'SOLO'
+        - 'SOLO_COM'
+        - 'SPECIAL_SLEEPER'
+        - 'TABLE'
+        - 'TANDEM'
+        - 'TOURIST_SLEEPER_2'
+        - 'TOURIST_SLEEPER_3'
+        - 'TOURIST_SLEEPER_4'
+        - 'TOURIST_SLEEPER_3_SWC'
+        - 'UPPER_BED'
+        - 'UPPER_DECK'
+        - 'VIDEO'
+        - 'WHEELCHAIR'
+        - 'WHEELCHAIR_AND_SEAT'
+        - 'WHEELCHAIR_NO_SEAT'
+        - 'WIFI'
+        - 'WINDOW'
+        - 'WITH_ANIMALS'
+        - 'WITH_SMALL_CHILDREN'
+        - 'WITHOUT_ANIMALS'
 
     AccommodationType:
       type: string
@@ -5096,11 +5283,11 @@ components:
       default: 'SEAT'
       nullable: false
       x-extensible-enum:
-        - "SEAT"
-        - "COUCHETTE"
-        - "BERTH"
-        - "VEHICLE"
-        - "STORAGE"
+        - 'SEAT'
+        - 'COUCHETTE'
+        - 'BERTH'
+        - 'VEHICLE'
+        - 'STORAGE'
 
     ActualPassengerType:
       description: |
@@ -5135,6 +5322,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -5225,37 +5415,37 @@ components:
       properties:
         countryName:
           description: |
-                Country of the address.
+            Country of the address.
           type: string
           nullable: true
           example: The Netherlands
         countryCode:
-            $ref: '#/components/schemas/CountryCode'
+          $ref: '#/components/schemas/CountryCode'
         postCode:
-            description: |
-                Postal code of the address.
-            type: string
-            nullable: true
-            example: 2265CA
+          description: |
+            Postal code of the address.
+          type: string
+          nullable: true
+          example: 2265CA
         city:
-            description: |
-                City name
-            type: string
-            nullable: true
-            example: Leidschendam
+          description: |
+            City name
+          type: string
+          nullable: true
+          example: Leidschendam
         street:
-            description: |
-              Street name of the address. Can also contain the house number.
-            type: string
-            nullable: true
-            example: Oude Trambaan
+          description: |
+            Street name of the address. Can also contain the house number.
+          type: string
+          nullable: true
+          example: Oude Trambaan
         houseNumber:
-            description: |
-              House number of the address. House number can either be in this separate field, or can be
-              contained in the street field.
-            type: string
-            nullable: true
-            example: 7
+          description: |
+            House number of the address. House number can either be in this separate field, or can be
+            contained in the street field.
+          type: string
+          nullable: true
+          example: 7
 
     Admission:
       description: |
@@ -5377,7 +5567,7 @@ components:
           default: false
 
     AfterSalesOverrideDetails:
-      description: | 
+      description: |
         If initial after sales conditions have been overwritten this object provides details on the original
         conditions and an explanation text for the customer
       type: object
@@ -5387,7 +5577,8 @@ components:
           items:
             $ref: '#/components/schemas/AfterSaleCondition'
         overrideDescription:
-          description: Description for the change of conditions for the customer.
+          description:
+            Description for the change of conditions for the customer.
           type: string
         validFrom:
           type: string
@@ -5601,7 +5792,7 @@ components:
         - 'BOOKING'
         - 'TRIP'
         - 'OFFERPART'
-        - 'SEAT_SELECTION' :  (https://osdm.io/spec/processes/#SeatSelectionFees)
+        - 'SEAT_SELECTION': (https://osdm.io/spec/processes/#SeatSelectionFees)
 
     TransactionContextType:
       type: string
@@ -5634,6 +5825,11 @@ components:
           nullable: false
         tripCoverage:
           $ref: '#/components/schemas/TripCoverage'
+        appliedReductionCardTypes:
+          deprecated: true
+          type: array
+          items:
+            $ref: '#/components/schemas/ReductionCardType'
         appliedReductions:
           type: array
           items:
@@ -5649,18 +5845,21 @@ components:
 
     AvailabilityScope:
       type: object
-      description: fare or offerParts which should be covered by the available seats
+      description:
+        fare or offerParts which should be covered by the available seats
       required:
         - partReferences
       properties:
         singleSelectionMapsRequired:
-          description: if true the place map must include places for a single reservation or fare only
+          description:
+            if true the place map must include places for a single reservation
+            or fare only
           type: boolean
           default: true
         partReferences:
           type: array
           items:
-             $ref: '#/components/schemas/PartReference'
+            $ref: '#/components/schemas/PartReference'
 
     PartReference:
       type: object
@@ -5737,9 +5936,15 @@ components:
             graphical reservation is supported, interface type 'WITH_FEE', 'NO', (https://osdm.io/spec/processes/#SeatSelectionFees)
           type: string
           x-extensible-enum:
-             - 'WITHOUT_FEE' : No additional fees will be added during seat selection. All fees are already linked with the reservation offer or booking
-             - 'WITH_FEE' : Additional selection fees might be applied in the seat selection. In case selection fees are applied this must be indicated here (https://osdm.io/spec/processes/#SeatSelectionFees)
-             - 'NO': No graphical reservation supported
+            - 'WITHOUT_FEE':
+                No additional fees will be added during seat selection. All fees
+                are already linked with the reservation offer or booking
+            - 'WITH_FEE':
+                Additional selection fees might be applied in the seat
+                selection. In case selection fees are applied this must be
+                indicated here
+                (https://osdm.io/spec/processes/#SeatSelectionFees)
+            - 'NO': No graphical reservation supported
           nullable: true
 
     BackOfficeStatus:
@@ -5881,13 +6086,14 @@ components:
         The attribute 'offerSummary' is meaningful at trip-offer-collection response time only.
       required:
         - offerId
-        - products
       properties:
         offerId:
           type: string
           maxLength: 32768
           nullable: false
-          description: Note that the offerId returned does not necessarily match the offerId given in the Booking Request.
+          description:
+            Note that the offerId returned does not necessarily match the
+            offerId given in the Booking Request.
         externalRef:
           description: |
             A stable reference to the id of the booked offer in the caller's system. When received in input of a request, it must be persisted and echoed back in the response.
@@ -5928,7 +6134,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Product'
-          minItems: 1  
 
     BookedOfferAncillaryRequest:
       type: object
@@ -5959,6 +6164,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -5983,6 +6191,13 @@ components:
           items:
             $ref: '#/components/schemas/OfferSelection'
           minItems: 1
+        passengers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Passenger'
+          deprecated: true
+          description: |
+            Existing passengers are linked with the given booking and do not need to be referenced in the request.
         additionalPassengerSpecifications:
           type: array
           items:
@@ -6027,6 +6242,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6040,10 +6258,16 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
             $ref: '#/components/schemas/Problem'
+        bookedOffer:
+          $ref: '#/components/schemas/BookedOffer'
+          deprecated: true
         bookedOfferIds:
           type: array
           items:
@@ -6217,6 +6441,9 @@ components:
       required:
         - events
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6318,7 +6545,9 @@ components:
       properties:
         externalRef:
           type: string
-          description: The unique booking reference in the distributor/retailer system. Usually refers to an order number or PNR.
+          description:
+            The unique booking reference in the distributor/retailer system.
+            Usually refers to an order number or PNR.
           nullable: true
         placeSelections:
           type: array
@@ -6363,7 +6592,7 @@ components:
         requestedFulfillmentType:
           $ref: '#/components/schemas/FulfillmentType'
         preferredFulfillmentMedia:
-          $ref: '#/components/schemas/FulfillmentMediaType'            
+          $ref: '#/components/schemas/FulfillmentMediaType'
         embed:
           description: |
             Influences whether referenced resources are returned in full or as references only.
@@ -6378,6 +6607,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6428,7 +6660,7 @@ components:
         destination:
           $ref: '#/components/schemas/PlaceRef'
         passenger:
-          $ref: '#/components/schemas/PersonSearchRequest'
+          $ref: '#/components/schemas/PassengerSearchRequest'
         purchaser:
           $ref: '#/components/schemas/PurchaserSearchRequest'
         bookingId:
@@ -6443,6 +6675,16 @@ components:
           description: reference to the booking in the retailer system
           type: string
           nullable: true
+        distributorBookingRef:
+          description: |
+            reference to the booking in the downstream distributor system
+          type: string
+          nullable: true
+          deprecated: true
+        retailerBookingRef:
+          type: string
+          nullable: true
+          deprecated: true
         fulfillmentId:
           type: string
           nullable: true
@@ -6460,6 +6702,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6495,15 +6740,15 @@ components:
           nullable: false
         provisionalPrice:
           description: |
-             price of all unconfirmed pre-booked parts in the booking
+            price of all unconfirmed pre-booked parts in the booking
           $ref: '#/components/schemas/Price'
         provisionalRefundAmount:
           description: |
-             sum of the refund amounts of all unconfirmed pre-booked refunds and exchanges
+            sum of the refund amounts of all unconfirmed pre-booked refunds and exchanges
           $ref: '#/components/schemas/Price'
         confirmedPrice:
           description: |
-             sum of all prices of confirmed parts in the booking minus the sum of all confirmed refund amounts.
+            sum of all prices of confirmed parts in the booking minus the sum of all confirmed refund amounts.
           $ref: '#/components/schemas/Price'
         bookedOfferSummaries:
           type: array
@@ -6561,6 +6806,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6594,11 +6842,11 @@ components:
           nullable: true
         dates:
           description: |
-            dates included in the calendar.
+            dates included in the calendar. In case no dates are provided the range is assumed to be valid. The date-time format is used to provide an offset to UTC per date.
           type: array
           items:
             type: string
-            format: date
+            format: date-time
           nullable: true
         utcOffset:
           description: |
@@ -6666,6 +6914,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6704,6 +6955,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -6977,7 +7231,7 @@ components:
         directedInternals:
           type: array
           items:
-            $ref: '#/components/schemas/CoachLayoutDirectedInternal'               
+            $ref: '#/components/schemas/CoachLayoutDirectedInternal'
         compartmentNumbers:
           type: array
           items:
@@ -6995,6 +7249,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -7050,11 +7307,11 @@ components:
           type: string
           nullable: false
         direction:
-          $ref: '#/components/schemas/DirectionType'          
+          $ref: '#/components/schemas/DirectionType'
         mounting:
           $ref: '#/components/schemas/MountingType'
         coords:
-          $ref: '#/components/schemas/LayoutCoordinates'            
+          $ref: '#/components/schemas/LayoutCoordinates'
 
     CoachLayoutPlace:
       type: object
@@ -7085,6 +7342,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -7110,7 +7370,9 @@ components:
           $ref: '#/components/schemas/LayoutCoordinates'
 
     CoachLayoutCompartmentNumber:
-      description: Layout item to place a compartment number. The number has no icon, it only places the number
+      description:
+        Layout item to place a compartment number. The number has no icon, it
+        only places the number
       type: object
       additionalProperties: false
       required:
@@ -7159,6 +7421,12 @@ components:
         registrationNumber:
           type: string
           nullable: false
+        legalAddress:
+          $ref: '#/components/schemas/Address'
+          deprecated: true
+          nullable: true
+          description: |
+            Deprecated in favor of `legalPostalAddress`
         legalPostalAddress:
           $ref: '#/components/schemas/PostalAddress'
         taxId:
@@ -7208,16 +7476,7 @@ components:
         serviceClass:
           $ref: '#/components/schemas/ServiceClassType'
         selectionFee:
-          $ref: '#/components/schemas/SelectionFee'               
-
-    ComplaintRequest:
-      type: object
-      additionalProperties: false
-      required:
-        - customerComplaint
-      properties:
-        customerComplaint:
-           $ref: '#/components/schemas/CustomerComplaint'
+          $ref: '#/components/schemas/SelectionFee'
 
     Complaint:
       type: object
@@ -7317,6 +7576,9 @@ components:
       properties:
         complaint:
           $ref: '#/components/schemas/Complaint'
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -7380,6 +7642,10 @@ components:
             Preferably a mobile phone number, to be contacted in case changes to the booking occur, e.g., in case of delays or interruptions .
           type: string
           nullable: true
+        address:
+          type: string
+          nullable: true
+          deprecated: true
         postalAddress:
           $ref: '#/components/schemas/PostalAddress'
           nullable: true
@@ -7534,10 +7800,6 @@ components:
     CustomerComplaint:
       type: object
       additionalProperties: false
-      required:
-        - applicationTime
-        - journeyDetails
-        - affectedPassengers
       description: |
         complaint details provided by the passengers
       properties:
@@ -7555,7 +7817,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Passenger'
-          minItems: 1  
         supportingDocuments:
           type: array
           items:
@@ -7693,20 +7954,6 @@ components:
           type: string
           format: date-time
           nullable: true
-        documentContent:
-          nullable: true
-          $ref: '#/components/schemas/DocumentContent'
-        type:
-          $ref: '#/components/schemas/DocumentType'
-        scope:
-          $ref: '#/components/schemas/DocumentScope'
-
-    DocumentContent:
-      type: object
-      required:
-        - content
-        - format
-      properties:
         content:
           description: |
             base64 encoded binary of the actual fulfillment document. The length restriction of 4 MBytes applies to the encoded
@@ -7714,11 +7961,14 @@ components:
           type: string
           format: byte
           maxLength: 4194304
-          nullable: false
+          nullable: true
         format:
           $ref: '#/components/schemas/DocumentFormat'
-          nullable: false
-
+          nullable: true
+        type:
+          $ref: '#/components/schemas/DocumentType'
+        scope:
+          $ref: '#/components/schemas/DocumentScope'
 
     DocumentCollectionResponse:
       type: object
@@ -7726,6 +7976,9 @@ components:
       required:
         - documents
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -7749,6 +8002,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -7875,7 +8130,6 @@ components:
       required:
         - exchangeFee
         - exchangePrice
-        - refundableAmount
         - fulfillments
         - offerId
         - createdOn
@@ -8049,6 +8303,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -8156,6 +8413,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -8498,6 +8758,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Condition'
+        productCode:
+          description: |
+            The product code expressed in the provider system (could be a
+            mapping from an even lower-level provider).
+          type: string
+          nullable: true
+          deprecated: true
         productRef:
           type: string
           description: |
@@ -8630,6 +8897,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -8776,10 +9046,12 @@ components:
     FulfillmentMediaType:
       description: |
         Fulfillment types. RCT2, RCCST and UIC_PDF are official UIC standards.
+        Notice:`ALLOCATOR_APP` is deprecated and should not be used anymore. The `ALLOCATOR_APP` type is replaced by the `RETAILER_APP` type. `DISTRIBUTOR_APP` was introduced to distinguish between the different types of apps that can be used to fulfill a booking.
         Values from the [Fulfillment Media Type Code List](https://osdm.io/spec/catalog-of-code-lists/#FulfillmentMediaType)
         Listed values here are examples.
       type: string
       x-extensible-enum:
+        - 'ALLOCATOR_APP' # deprecated
         - 'DISTRIBUTOR_APP'
         - 'RETAILER_APP'
         - 'FULFILLMENT_PARTS'
@@ -8887,12 +9159,18 @@ components:
       properties:
         issuingLanguage:
           type: string
-          description: the desired issuing language (ISO-639-1 language code). If not provided or not available, will default to (one of) the language(s) of the issuing country
+          description:
+            the desired issuing language (ISO-639-1 language code). If not
+            provided or not available, will default to (one of) the language(s)
+            of the issuing country
 
     FulfillmentResponse:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -9035,8 +9313,8 @@ components:
             ids of the passengers that were granted the reduction
           type: array
           items:
-             type: string
-             nullable: false
+            type: string
+            nullable: false
         tripCoverage:
           $ref: '#/components/schemas/TripCoverage'
         appliedPassengerTypes:
@@ -9055,8 +9333,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PromotionCode'
-
-
 
     HistoryStatus:
       type: string
@@ -9964,6 +10240,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -10003,7 +10282,7 @@ components:
 
         Individual offer mode means that each passenger is given individual admissions and reservations  to allow to refund individual passengers booked in a single booking.
 
-        If collective mode is not supported, reverts back to the other mode and provides problem with warning message instead.
+        If collective mode is not supported,  reverts back to the other mode and provides warning instead.
 
       type: string
       enum:
@@ -10274,6 +10553,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -10507,6 +10789,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -10623,6 +10908,12 @@ components:
         - firstName
         - lastName
       properties:
+        preferredLanguage:
+          description: |
+            ISO-639-1 language code
+          type: string
+          deprecated: true
+          nullable: true
         summary:
           description: |
             A human-readable description of the person.
@@ -10650,6 +10941,23 @@ components:
           type: string
           nullable: false
           example: 'Lopez'
+        email:
+          type: string
+          deprecated: true
+          nullable: true
+        phoneNumber:
+          description: |
+            Preferably a mobile phone number, to be contacted in case changes to the booking occur, e.g.,
+            in case of interruptions.
+          type: string
+          deprecated: true
+          nullable: true
+        address:
+          $ref: '#/components/schemas/Address'
+          nullable: true
+          deprecated: true
+          description: |
+            Deprecated in favor of `postalAddress`
         postalAddress:
           $ref: '#/components/schemas/PostalAddress'
           nullable: true
@@ -10665,10 +10973,16 @@ components:
           nullable: true
           example: CZ1234567890
 
-    PersonSearchRequest:
+    PassengerSearchRequest:
       type: object
       additionalProperties: false
       properties:
+        externalRef:
+          description: |
+            A stable reference to a person from other elements, or from caller system.
+            When received in input of a request, it must be echoed back in the response.
+          type: string
+          nullable: true
         firstName:
           type: string
           nullable: true
@@ -10724,7 +11038,6 @@ components:
           $ref: '#/components/schemas/PlaceRef'
         _links:
           description: |
-
             Java Property Name: 'links'
           type: array
           items:
@@ -10779,6 +11092,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -10792,27 +11108,15 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
             $ref: '#/components/schemas/Problem'
         vehicleAvailability:
           $ref: '#/components/schemas/PlaceAvailability'
-
-
-    PlaceAvailabilitiesResponse:
-      type: object
-      additionalProperties: false
-      properties:
-        problems:
-          type: array
-          items:
-            $ref: '#/components/schemas/Problem'
-        vehicleAvailabilities:
-          type: array
-          items:
-            $ref: '#/components/schemas/PlaceAvailability'
-          maxItems: 50
 
     PlaceParam:
       type: object
@@ -10859,7 +11163,7 @@ components:
           $ref: '#/components/schemas/AvailabilityStatus'
         reservationRefs:
           description: |
-            references to the reservations for which this place nca be selected. The reservation ids must be part of the list of reservation ids for which the consumer has requested the available places and the consumer must accept a list by setting singleSelectionMapsRequired to false
+            references to the reservations for which this place can be selected. The reservation ids must be part of the list of reservation ids for which the consumer has requested the available places and the consumer must accept a list by setting singleSelectionMapsRequired to false
           type: array
           items:
             type: string
@@ -10868,7 +11172,7 @@ components:
           items:
             $ref: '#/components/schemas/PlaceProperty'
         selectionFee:
-          $ref: '#/components/schemas/SelectionFee'                  
+          $ref: '#/components/schemas/SelectionFee'
 
     PlacePreSelection:
       type: object
@@ -10915,7 +11219,7 @@ components:
     PlaceProperty:
       type: string
       description: |
-         Values from the [Place Property Code List](https://osdm.io/spec/catalog-of-code-lists/#PlaceProperty)
+        Values from the [Place Property Code List](https://osdm.io/spec/catalog-of-code-lists/#PlaceProperty)
       nullable: false
       example: Power Connection
 
@@ -10951,6 +11255,9 @@ components:
       required:
         - places
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11190,16 +11497,6 @@ components:
             nullable: true
           minItems: 0
 
-    ProblemCollection:
-      type: object
-      required:
-        - problems
-      properties:
-        problems:
-          type: array
-          items:
-            $ref: '#/components/schemas/Problem'
-
     ProblemPointer:
       type: object
       additionalProperties: false
@@ -11260,22 +11557,19 @@ components:
             A pointer to the attribute in the request for the problem.
           type: string
           nullable: true
-          example:
-            "#/offers[1]/placeSelections[1]/reservationId"
+          example: '#/offers[1]/placeSelections[1]/reservationId'
         responsePointer:
           description: |
             A pointer to the attribute in the response for the problem.
           type: string
           nullable: true
-          example:
-            "#/booking/bookedOffers[4]/reservations[1]/id"
+          example: '#/booking/bookedOffers[4]/reservations[1]/id'
         originator:
           description: |
             Identifier to the origin server for this occurrence of the problem.
           type: string
           nullable: true
-          example:
-            IMS1
+          example: IMS1
 
     Product:
       type: object
@@ -11359,11 +11653,14 @@ components:
           items:
             $ref: '#/components/schemas/CombinationTag'
         productTags:
-          description: product tags associated with the product that can be used to search for offers. This can be omitted outside of the product master data service
+          description:
+            product tags associated with the product that can be used to search
+            for offers. This can be omitted outside of the product master data
+            service
           type: array
           items:
-             type: string
-             nullable: true
+            type: string
+            nullable: true
         _links:
           description: |
             Java Property Name: 'links'
@@ -11441,6 +11738,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11477,6 +11777,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11555,6 +11857,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11566,6 +11871,12 @@ components:
       type: object
       additionalProperties: false
       properties:
+        externalRef:
+          description: |
+            A stable reference to a purchaser from other elements, or from caller system.
+            When received in input of a request, it must be echoed back in the response.
+          type: string
+          nullable: true
         companyName:
           type: string
           nullable: true
@@ -11581,6 +11892,7 @@ components:
           type: string
           format: date
           nullable: true
+          deprecated: true
         phoneNumber:
           type: string
           nullable: true
@@ -11635,10 +11947,13 @@ components:
             type:
               $ref: '#/components/schemas/ReductionCardType'
 
-    ReductionCardTypeCollectionResponse:
+    ReductionCardCollectionResponse:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11660,11 +11975,11 @@ components:
           type: string
           nullable: false
         shortCode:
-          description:  |
+          description: |
             reduction card code to be used in bar codes. The code is defined within
             the context of the issuer and is required to be very short (usually 1-4 positions).
             The code is used in ticket bar codes to indicate required checks of this reduction card during travel.
-          type: string          
+          type: string
           nullable: true
         issuer:
           $ref: '#/components/schemas/CompanyRef'
@@ -11689,13 +12004,6 @@ components:
           items:
             $ref: '#/components/schemas/ServiceClassType'
           maxItems: 4
-        travelClassTypes:
-          description: |
-            list of travel classes where this card applies
-          type: array
-          items:
-            $ref: '#/components/schemas/TravelClass'
-          maxItems: 2
         _links:
           description: |
 
@@ -11791,7 +12099,7 @@ components:
             breakdown of the refund offer
           type: array
           items:
-             $ref: '#/components/schemas/RefundOfferBreakdownItem'
+            $ref: '#/components/schemas/RefundOfferBreakdownItem'
         reimbursementMethod:
           $ref: '#/components/schemas/ReimbursementMethod'
         _links:
@@ -11823,6 +12131,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -11887,6 +12198,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -12139,12 +12453,15 @@ components:
       required:
         - reimbursement
       properties:
+        reimbursement:
+          $ref: '#/components/schemas/Reimbursement'
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
             $ref: '#/components/schemas/Problem'
-        reimbursement:
-          $ref: '#/components/schemas/Reimbursement'
 
     ReimbursementStatus:
       type: string
@@ -12214,6 +12531,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -12252,7 +12572,7 @@ components:
             To do a partial release repeat the fulfillmentIds affected and point out what to release
           type: array
           items:
-            $ref: '#/components/schemas/RefundSpecification'            
+            $ref: '#/components/schemas/RefundSpecification'
         overruleCode:
           $ref: '#/components/schemas/OverruleCode'
 
@@ -12260,6 +12580,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -12327,12 +12650,16 @@ components:
               items:
                 $ref: '#/components/schemas/BookingPartReference'
             availablePlacePreferences:
-              description: options for place selection in case the place selection is made after the pre-booking.
+              description:
+                options for place selection in case the place selection is made
+                after the pre-booking.
               type: array
               items:
                 $ref: '#/components/schemas/AvailablePlacePreferences'
             graphicalReservationSupported:
-              description: more detailed information on options for place selection and possible fees are part of availablePlacePreferences
+              description:
+                more detailed information on options for place selection and
+                possible fees are part of availablePlacePreferences
               type: boolean
               nullable: true
               default: false
@@ -12722,7 +13049,9 @@ components:
 
     SelectionFee:
       type: object
-      description: selection fee that will be applied when selecting the place in a graphical seat map. (https://osdm.io/spec/processes/#SeatSelectionFees)
+      description:
+        selection fee that will be applied when selecting the place in a
+        graphical seat map. (https://osdm.io/spec/processes/#SeatSelectionFees)
       properties:
         price:
           $ref: '#/components/schemas/Price'
@@ -13046,6 +13375,7 @@ components:
       description: |
         Directly included text in case of online services. Text must be encoded in UTF-8 format.
       required:
+        - id
         - text
       properties:
         id:
@@ -13442,6 +13772,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -13727,6 +14060,9 @@ components:
       required:
         - id
       properties:
+        warning:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -14010,6 +14346,9 @@ components:
       required:
         - trip
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:
@@ -14030,7 +14369,7 @@ components:
       additionalProperties: false
       description: |
         The trip result to be changed.
-      properties:        
+      properties:
         TripSummary:
           $ref: '#/components/schemas/TripSpecificationSummary'
 
@@ -14051,7 +14390,7 @@ components:
           nullable: true
         arrivalTime:
           description: |
-            Needs to be in local date time format of the stop. Exactly one of `departureTime` and `arrivalTime` must be provided.
+            Needs to in be local date time format of the stop. Exactly one of `departureTime` and `arrivalTime` must be provided.
           type: string
           pattern: '(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)'
           nullable: true
@@ -14411,6 +14750,61 @@ components:
           type: string
           nullable: false
 
+    Warning:
+      type: object
+      additionalProperties: false
+      description: |
+        This element can be used to pass non-blocking information or events,
+        such as a price difference with the initially offered price at booking time.
+        It is inspired on the JSon problem structure.
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          nullable: false
+        type:
+          description: |
+            An absolute URI that identifies the warning type. When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          type: string
+          format: uri
+          nullable: true
+          default: 'about:blank'
+          example: https://example.com/warns/price-updated
+        detail:
+          description: |
+            A human readable explanation specific to this occurrence of the
+            warning.
+          type: string
+          nullable: true
+          example:
+            The price of the given offer part has been updated during the
+            booking operation
+        instance:
+          description: |
+            An absolute URI that identifies the specific occurrence of the warning.
+          type: string
+          format: uri
+          nullable: true
+          example: offers/offer1234
+
+    WarningCollection:
+      type: object
+      additionalProperties: false
+      description: |
+        List of warnings.
+
+      required:
+        - warnings
+      properties:
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Warning'
+          minItems: 1
+
     Zone:
       type: object
       additionalProperties: false
@@ -14456,6 +14850,9 @@ components:
       type: object
       additionalProperties: false
       properties:
+        warnings:
+          deprecated: true
+          $ref: '#/components/schemas/WarningCollection'
         problems:
           type: array
           items:

--- a/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
+++ b/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
@@ -4925,8 +4925,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PromotionCode'
-        regionalValiditySummary:
-          $ref: '#/components/schemas/RegionalValiditySummary'
         indicatedConsumption:
           $ref: '#/components/schemas/IndicatedConsumption'
         grantedReductionAmounts:
@@ -5298,6 +5296,8 @@ components:
         - type: object
           additionalProperties: false
           properties:
+            regionalValiditySummary:
+              $ref: '#/components/schemas/RegionalValiditySummary'
             regionalValidity:
               $ref: '#/components/schemas/RegionalValidity'
             isReservationRequired:
@@ -5494,6 +5494,10 @@ components:
           required:
             - type
           properties:
+            regionalValiditySummary:
+              $ref: '#/components/schemas/RegionalValiditySummary'
+            regionalValidity:
+              $ref: '#/components/schemas/RegionalValidity'
             feeRefs:
               type: array
               items:


### PR DESCRIPTION
I have prepared the PR for #742 RegionalValidity for Admission and AdmissionOfferPart. Backport version 3.4.1 is also included.

BEFORE APPROVING, I have found that `regionalValiditiySummary` is not part of Admission, but in AbstractOfferPart so it is available to ReservationOfferParts and AncillaryOfferParts. Is that correct? Also it is missing from BookedOfferParts. Should we also add it there?
