### PR TITLE
Demo-App: add version indicator

### DIFF
--- a/demo-app/src/App.vue
+++ b/demo-app/src/App.vue
@@ -7,9 +7,10 @@
       </div>
     </header>
     <RouterView />
-    <footer class="bg-osdm-bg-primary text-sm text-osdm-text-inverted flex justify-center p-4">
-      <p>Developed with ♥ for OSDM by <a href="https://xatellite.space" target="_blank">xatellite</a> and <a
-          href="https://bileto.cz" target="_blank">bileto</a>.</p>
+    <footer class="flex flex-col bg-osdm-bg-primary text-sm text-osdm-text-inverted justify-center items-center p-4">
+      <span>Developed with ♥ for OSDM by <a href="https://xatellite.space" target="_blank">xatellite</a> and <a
+          href="https://bileto.cz" target="_blank">bileto</a>.</span>
+      <span>{{ version }}</span>
     </footer>
   </div>
 </template>
@@ -22,6 +23,11 @@ export default {
   components: {
     RouterView,
     SandboxSettings,
+  },
+  data() {
+    return {
+      version: __VERSION__,
+    }
   },
 }
 </script>

--- a/demo-app/vite.config.ts
+++ b/demo-app/vite.config.ts
@@ -1,11 +1,27 @@
 import { fileURLToPath, URL } from 'node:url'
+import { exec } from "child_process"
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
+const getVersionInfo = async () => {
+  return await new Promise((resolve) => {
+    exec('git describe --tags --always', (error, stdout) => {
+      if (error) {
+        console.error(`Error getting version number: ${error}`);
+        resolve ('unknown');
+      }
+      resolve(stdout.trim());
+    });
+  });
+};
+
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(async () => {
+  const version = await getVersionInfo();
+
+  return {
   plugins: [
     vue({
       template: {
@@ -17,10 +33,13 @@ export default defineConfig({
     }),
     vueDevTools(),
   ],
+  define: {
+    __VERSION__: JSON.stringify(version),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
       '@sbb-esta': fileURLToPath(new URL('./node_modules/@sbb-esta', import.meta.url)),
     },
   },
-})
+}})


### PR DESCRIPTION
To check if an instance is running the current version of the demo app this PR adds a version indication retrieved from `git describe --tags --always`