### PR TITLE
874 overrule cleanup

### DIFF
--- a/specification/v3.5/OSDM-online-api-v3.5.0.yml
+++ b/specification/v3.5/OSDM-online-api-v3.5.0.yml
@@ -1867,6 +1867,7 @@ paths:
       summary: Performs a complete cleanup of a booking in a single step
       description: |
         The booking is cleaned up completely: confirmed items are refunded, and unconfirmed items are deleted.
+        -- Attention point: refundDate and overruleCode are deprecated request attributes and will be ignored
       operationId: postBookingCleanup
       parameters:
         - $ref: '#/components/parameters/requestor'
@@ -6649,12 +6650,14 @@ components:
       description: |
         Request to cleanup a complete booking.
         Unconfirmed items will be deleted, any confirmed items will be refunded. There is no confirmation required.
+        Attention point: refundDate and overruleCode are deprecated request attributes and will be ignored
       properties:
         overruleCode:
           $ref: '#/components/schemas/OverruleCode'
+          description: --Deprecated -- 
         refundDate:
           description: |
-            Indicates for passes the date taken as reference to compute possible partial refund. It is also the date taken
+            --Deprecated -- Indicates for passes the date taken as reference to compute possible partial refund. It is also the date taken
             as reference to invalidate the pass partially refunded.
           type: string
           format: date-time

--- a/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
+++ b/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
@@ -6362,17 +6362,7 @@ components:
       description: |
         Request to cleanup a complete booking.
         Unconfirmed items will be deleted, any confirmed items will be refunded. There is no confirmation required.
-      properties:
-        overruleCode:
-          $ref: '#/components/schemas/OverruleCode'
-        refundDate:
-          description: |
-            Indicates for passes the date taken as reference to compute possible partial refund. It is also the date taken
-            as reference to invalidate the pass partially refunded.
-          type:
-            - 'string'
-            - 'null'
-          format: date-time
+      
 
     BookingHistoryResponse:
       type: object


### PR DESCRIPTION
marking overrule code and refund date as deprecated in 3.5. removed in 4.0