### PR TITLE
Update OSDM-online-api-v4.0.0-draft.yml

### DIFF
--- a/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
+++ b/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
@@ -7827,9 +7827,6 @@ components:
           items:
             $ref: '#/components/schemas/RefundedFulfillmentSpecification'
           minItems: 1 
-        appliedOverruleCode:
-          $ref: '#/components/schemas/OverruleCode'
-          minItems: 1
         issuedFulfillmentIds:
           description:
             IDs of the new fulfillments issued with this refund


### PR DESCRIPTION
"appliedOverruleCode" appeared twice in the ConfirmedRefund structure. One must be removed.