### PR TITLE
#1142 Fix duplicate operationId for bulk passenger patch

### DIFF
--- a/specification/v3.7/OSDM-online-api-v3.7.0.yml
+++ b/specification/v3.7/OSDM-online-api-v3.7.0.yml
@@ -1133,7 +1133,7 @@ paths:
       tags:
         - Passengers
       summary: Allows updating a set of passengers in a batch at booking step.
-      operationId: patchBookingPassenger
+      operationId: patchBookingPassengers
       parameters:
         - $ref: '#/components/parameters/requestor'
         - $ref: '#/components/parameters/acceptLanguage'


### PR DESCRIPTION
Fix for generator issue:

```
Execution failed for task ':openApiGenerate'.
> There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
   | Error count: 1, Warning count: 3
  Errors:
        -attribute paths.'/bookings/{bookingId}/passengers'(patch).operationId is repeated
  Warnings:
        -attribute paths.'/bookings/{bookingId}/passengers'(patch).operationId is repeated
```