### PR TITLE
#1157 DRAFT

### DIFF
--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -1,0 +1,27 @@
+name: Validate OpenAPI Documents
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: latest
+
+      - name: Install redocly cli
+        run: npm i -g @redocly/cli@latest
+
+      - name: Validate OpenAPI documents
+        run: redocly lint --format=github-actions specification/**/*.yml

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,296 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redocly.com/docs/cli/ for more information.
+specification/v1.4.0/OSDM-online-api-v1.4.0.yml:
+  no-unused-components:
+    - '#/components/schemas/SelectedPlaces'
+specification/v1.4.0/OSDM-online-api-v1.4.1.yml:
+  no-unused-components:
+    - '#/components/schemas/SelectedPlaces'
+    - '#/components/responses/ConflictResponse'
+specification/v1.4.0/OSDM-online-webhook-v1.4.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v2.0.0/OSDM-online-api-v2.0.0.yml:
+  no-unused-components:
+    - '#/components/responses/ConflictResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.1.yml:
+  no-unused-components:
+    - '#/components/responses/ConflictResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.2.yml:
+  no-unused-components:
+    - '#/components/responses/ConflictResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.3.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+    - '#/components/responses/ConflictResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.4.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+    - '#/components/responses/ConflictResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.5.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.6.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.7.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+specification/v2.0.0/OSDM-online-api-v2.0.8.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferResponse'
+specification/v2.0.0/OSDM-online-webhook-v2.0.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.0/OSDM-online-api-v3.0.0.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.1.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.2.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.3.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.4.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.5.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.6.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-api-v3.0.7.yml:
+  no-unused-components:
+    - '#/components/schemas/BookedOfferAncillaryPatchRequest'
+    - '#/components/schemas/BookedOfferAncillaryPatchResponse'
+    - '#/components/schemas/BookedOfferReservationPatchRequest'
+    - '#/components/schemas/BookedOfferReservationPatchResponse'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.0/OSDM-online-webhook-v3.0.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.0/OSDM-online-webhook-v3.0.1.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.1/OSDM-online-api-v3.1.0.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.1/OSDM-online-api-v3.1.1.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.1/OSDM-online-api-v3.1.2.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.1/OSDM-online-api-v3.1.3.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.2/OSDM-online-api-v3.2.0.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.2/OSDM-online-api-v3.2.1.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.2/OSDM-online-api-v3.2.2.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.2/OSDM-online-api-v3.2.3.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.2/OSDM-online-webhook-v3.2.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.3/OSDM-online-api-v3.3.0.yml:
+  no-unused-components:
+    - '#/components/schemas/ExchangeOfferItem'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.3/OSDM-online-api-v3.3.1.yml:
+  no-unused-components:
+    - '#/components/schemas/ExchangeOfferItem'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.3/OSDM-online-api-v3.3.2.yml:
+  no-unused-components:
+    - '#/components/schemas/ExchangeOfferItem'
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+    - '#/components/schemas/PlaceAvailabilitiesResponse'
+specification/v3.3/OSDM-online-webhook-v3.3.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.4/OSDM-online-api-v3.4.0.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.4/OSDM-online-api-v3.4.1.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.4/OSDM-online-api-v3.4.2.yml:
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.4/OSDM-online-webhook-v3.4.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.5/OSDM-online-api-v3.5.0.yml:
+  no-required-schema-properties-undefined:
+    - '#/components/schemas/ProductTagsResponse/required/1'
+    - '#/components/schemas/ProductTagsResponse/required/2'
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.5/OSDM-online-api-v3.5.1.yml:
+  no-required-schema-properties-undefined:
+    - '#/components/schemas/ProductTagsResponse/required/1'
+    - '#/components/schemas/ProductTagsResponse/required/2'
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.5/OSDM-online-api-v3.5.2.yml:
+  no-required-schema-properties-undefined:
+    - '#/components/schemas/ProductTagsResponse/required/1'
+    - '#/components/schemas/ProductTagsResponse/required/2'
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.5/OSDM-online-webhook-v3.5.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'
+specification/v3.6/OSDM-online-api-v3.6.0.yml:
+  no-required-schema-properties-undefined:
+    - '#/components/schemas/ProductTagsResponse/required/1'
+    - '#/components/schemas/ProductTagsResponse/required/2'
+  no-unused-components:
+    - '#/components/schemas/IndicatedTravelAccountConsumption'
+specification/v3.6/OSDM-online-webhook-v3.6.0.yml:
+  no-server-example.com:
+    - '#/servers/0/url'
+  operation-4xx-response:
+    - '#/paths/~1ping/get/responses'
+  operation-operationId:
+    - '#/webhooks/events/post/operationId'
+  operation-summary:
+    - '#/webhooks/events/post/summary'
+  struct:
+    - '#/webhooks/events/post/requestBody/content/application~1json/discriminator'
+  security-defined:
+    - '#/paths/~1ping/get'
+    - '#/webhooks/events/post'


### PR DESCRIPTION
This Github Action task uses `redocly lint` command to validate all YML files in specification subfolders. All errors in 1.4-3.6 were put into `.redocly.lint-ignore.yaml` so we don't need to modify already released versions.

**There are outstanding issues in 3.7 + 4.0 drafts that must be fixed before we merge this.**