### PR TITLE
Delete bookings endpoint description update

### DIFF
--- a/specification/v3.7/OSDM-online-api-v3.7.0.yml
+++ b/specification/v3.7/OSDM-online-api-v3.7.0.yml
@@ -2088,11 +2088,7 @@ paths:
         - Bookings
       summary: Deletes a booking.
       description: |
-        It is only possible before the booking is confirmed or in case of a technical problem in confirming multiple
-        independent bookings within a sales transaction. Deletes on a confirmed booking must be documented
-        and evidence on the issue must be provided on request.
-        The delete on a confirmed booking is allowed immediately after the confirmation of the booking,
-        but must be repeated according to the error handling rules in case the delete fails.
+        It is only possible before the booking is confirmed.
       operationId: deleteBookingsId
       parameters:
         - $ref: '#/components/parameters/requestor'

--- a/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
+++ b/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
@@ -1891,11 +1891,7 @@ paths:
         - Bookings
       summary: Deletes a booking.
       description: |
-        It is only possible before the booking is confirmed or in case of a technical problem in confirming multiple
-        independent bookings within a sales transaction. Deletes on a confirmed booking must be documented
-        and evidence on the issue must be provided on request.
-        The delete on a confirmed booking is allowed immediately after the confirmation of the booking,
-        but must be repeated according to the error handling rules in case the delete fails.
+        It is only possible before the booking is confirmed.
       operationId: deleteBookingsId
       parameters:
         - $ref: '#/components/parameters/requestor'


### PR DESCRIPTION
From: https://github.com/UnionInternationalCheminsdeFer/OSDM/issues/1187

Technical failures should be handle via the refund flow with overruleCode: TECHNICAL_FAILURE.

The DETELE /bookings/{bookingId} can be used only for pre-booking use cases, before the booking is confirmed/fulfilled.

The POST /bookings/{bookingId}/cleanup is an optional endpoint, refunds confirmed items, and delete the unconfirmed ones. This endpoint does not accept overruleCode and cannot be used for technical failures.