### PR TITLE
#1293 Fix backward compatibility

### DIFF
--- a/specification/v3.8/OSDM-online-api-v3.8.0.yml
+++ b/specification/v3.8/OSDM-online-api-v3.8.0.yml
@@ -8647,6 +8647,9 @@ components:
             $ref: '#/components/schemas/CoachLayoutCompartmentNumber'
         gridSize:
           $ref: '#/components/schemas/CoachLayoutGridSize'
+        _links:
+          $ref: '#/components/schemas/Links'
+          deprecated: true
 
     CoachLayoutCollectionResponse:
       type: object


### PR DESCRIPTION
#1293 Fix backward compatibility

Hello @samirm19, I merged your change for paging fixes but found you deleted at least one property. We cannot do that in OSDM 3. Now trying to recover and deprecate properly.