### PR TITLE
feat: add v3.9 to navigation and release notes

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,8 +18,10 @@
       link: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.6/OSDM-online-api-v3.6.3.yml
     - name: Online API v3.7.1 (stable version) - Swagger
       link: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.7/OSDM-online-api-v3.7.1.yml
-    - name: Online API v3.8.0 (draft version) - Swagger
+    - name: Online API v3.8.0 (stable version) - Swagger
       link: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.8/OSDM-online-api-v3.8.0.yml
+    - name: Online API v3.9.0 (draft version) - Swagger
+      link: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.9/OSDM-online-api-v3.9.0.bundled.yml
     - name: Online API v4.0.0 (draft version) - Swagger
       link: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml
 
@@ -55,10 +57,14 @@
       link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.7/OSDM-online-webhook-v3.7.0.yml&nocors
     - name: Online API v3.7.1 (stable version) - Redoc
       link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.7/OSDM-online-api-v3.7.1.yml&nocors
-    - name: Online API v3.8.0 Webhook (draft version) - Redoc
+    - name: Online API v3.8.0 Webhook (stable version) - Redoc
       link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.8/OSDM-online-webhook-v3.8.0.yml&nocors
-    - name: Online API v3.8.0 (draft version) - Redoc
+    - name: Online API v3.8.0 (stable version) - Redoc
       link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.8/OSDM-online-api-v3.8.0.yml&nocors
+    - name: Online API v3.9.0 Webhook (draft version) - Redoc
+      link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.9/OSDM-online-webhook-v3.9.0.yml&nocors
+    - name: Online API v3.9.0 (draft version) - Redoc
+      link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v3.9/OSDM-online-api-v3.9.0.bundled.yml&nocors
     - name: Online API v4.0.0 (draft version) - Redoc
       link: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/UnionInternationalCheminsdeFer/OSDM/master/specification/v4.0/OSDM-online-api-v4.0.0-draft.yml&nocors
 

--- a/releases/OSDM-release-notes-v3.9.md
+++ b/releases/OSDM-release-notes-v3.9.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: OSDM Release Version 3.9
+hide_hero: false
+permalink: /releases/OSDM-release-notes-v3.9/
+---
+
+## What's New in OSDM Version 3.9
+
+### Modularization of the Online API Specification
+
+The monolithic `OSDM-online-api-v3.8.0.yml` (18,112 lines) has been restructured into a modular multi-file format:
+
+- **Root hub file:** `OSDM-online-api.yml` (~150 lines) — entrypoint that assembles all modules via `$ref`
+- **24 path files** in `paths/` — one per API domain (trips, offers, bookings, fulfillments, etc.)
+- **15 schema files** in `schemas/` — organized by domain (`_common`, `trip`, `offer`, `booking`, `person`, `transportable`, etc.)
+- **3 component files** in `components/` — parameters, responses, security schemes
+
+A bundled single-file output (`OSDM-online-api-v3.9.0.bundled.yml`) is provided for consumers who require it.
+
+### New Schemas
+
+- **`person.yml`** — person and company identification, replacing the former `passenger.yml` references
+- **`transportable.yml`** — vehicle, car, motorcycle, and related transport schemas
+
+### No Functional API Changes
+
+This version contains no changes to the API surface — only the file organization has been restructured for maintainability and long-term extensibility.
+
+### Breaking Changes
+
+None. This version is fully backwards compatible with version 3.8.


### PR DESCRIPTION
## Summary

- Adds v3.9.0 API entries to the navigation dropdowns (Swagger and Redoc) pointing to the bundled spec
- Adds v3.9.0 webhook entry to the Redoc dropdown
- Promotes v3.8.0 from "draft" to "stable" in the navigation
- Creates `releases/OSDM-release-notes-v3.9.md`

## Test plan

- [ ] Verify navigation links render correctly on osdm.io after merge
- [ ] Verify Swagger/Redoc links resolve to the v3.9 bundled spec on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)