### PR TITLE
feat: add blog post for OSDM v3.8 release

### DIFF
--- a/_posts/2026-03-25-OSDM-V3.8-released.md
+++ b/_posts/2026-03-25-OSDM-V3.8-released.md
@@ -1,0 +1,39 @@
+---
+layout: post
+title: 'OSDM Version 3.8 Released'
+author: Andreas Schlapbach
+date: 2026-03-25 10:00:00 +0100
+categories: osdm update
+---
+
+We are proud to release **Version 3.8** of the
+[OSDM Specification](https://osdm.io/spec/). This increment brings a range of
+improvements contributed by the different parties. Highlights of this release
+include:
+
+- **Promotion codes** — new `GET /promotion-codes` endpoint and supporting
+  objects to enable discount and voucher workflows
+- **Compartment selection** — `PlaceSelection` extended with compartment
+  support via the new `SelectedCompartment` object
+- **Multilingual support** — translation properties added across a broad set of
+  objects (`Address`, `Condition`, `FareConnectionPoint`, `GeneralAttribute`,
+  `Product`, `Zone`, and more)
+- **Chip card fulfillment** — `CardReference` extended with
+  `chipCardContentFormat` and `chipCardContent` for on-chip ticket delivery
+- **Provider fee flag** — `Fee` and `AfterSalesConditionsLink` gain
+  `isProviderFee` to distinguish carrier fees from distributor fees
+- **Exchange and refund fees** — new `exchangeFee` on
+  `ExchangeOfferCollectionRequest` and `refundFee` on `RefundSpecification`
+- **Distribution mode** — new `DistributionMode` enum on
+  `ReservationOfferPart` for clearer reservation handling
+- **Fulfillment document references** — `Fulfillment` gains
+  `fulfillmentDocumentRefs` alongside improved document tracking across
+  fulfillment responses
+
+See the
+[Release Notes 3.8](https://osdm.io/releases/OSDM-release-notes-v3.8/)
+for the full list of changes.
+
+More to come!
+
+Thanks to all the [Team](https://osdm.io/team/) for its hard work.


### PR DESCRIPTION
## Summary

- Adds `_posts/2026-03-25-OSDM-V3.8-released.md` announcing the v3.8 release
- Highlights: promotion codes, compartment selection, multilingual translations, chip card fulfillment, provider fee flag, exchange/refund fees, distribution mode, fulfillment document refs

## Test plan

- [ ] Verify post appears in the blog on osdm.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)