### PR TITLE
feat: externalize FulfillmentDocument and introduce VoucherRef

### DIFF
--- a/specification/schemas/_common.yml
+++ b/specification/schemas/_common.yml
@@ -1696,6 +1696,7 @@ VatScope:
   - NOT_REGISTERED
 VoucherInformation:
   type: object
+  description: identifier of a voucher
   additionalProperties: false
   required:
   - issuer

--- a/specification/schemas/aftersales.yml
+++ b/specification/schemas/aftersales.yml
@@ -211,16 +211,16 @@ ConfirmedRefund:
       items:
         $ref: '#/RefundedFulfillmentSpecification'
       minItems: 1
-    issuedFulfillmentIds:
+    issuedFulfillmentRefs:
       description: |
-        IDs of the new fulfillments issued with this refund
+        new fulfillments issued with this refund (only available after confirmation)
       type: array
       items:
-        type: string
-    issuedVouchers:
+        $ref: ./fulfillment.yml#/FulfillmentRef
+    issuedVoucherRefs:
       type: array
       items:
-        $ref: ./_common.yml#/VoucherInformation
+        $ref: ./fulfillment.yml#/VoucherRef
     refundFeeRefs:
       description: |
         reference to Applied Fees covering the refund fee. Providing the reference
@@ -540,10 +540,10 @@ ExchangeOperation:
       type: array
       items:
         $ref: ./fulfillment.yml#/FulfillmentRefs
-    issuedVouchers:
+    issuedVoucherRefs:
       type: array
       items:
-        $ref: ./_common.yml#/VoucherInformation
+        $ref: ./fulfillment.yml#/VoucherRef
     trips:
       type: array
       items:

--- a/specification/schemas/fulfillment.yml
+++ b/specification/schemas/fulfillment.yml
@@ -202,12 +202,14 @@ Fulfillment:
       $ref: '#/FulfillmentUsage'
     issuer:
       $ref: ./_common.yml#/CompanyRef
-    fulfillmentDocuments:
+    fulfillmentDocumentRefs:
       description: |
-        Final document created for fulfillment.
+        References to the fulfillment documents.
       type: array
       items:
-        $ref: '#/FulfillmentDocument'
+        type: string
+        description: |
+          Fulfillment document ID
     issuingLanguage:
       type: string
       description: the issuing language (ISO-639-1 language code).
@@ -244,10 +246,16 @@ FulfillmentCollectionResponse:
       type: array
       items:
         $ref: '#/Fulfillment'
-    issuedVouchers:
+    fulfillmentDocuments:
       type: array
       items:
-        $ref: ./_common.yml#/VoucherInformation
+        $ref: '#/FulfillmentDocument'
+    issuedVoucherRefs:
+      type: array
+      items:
+        $ref: '#/VoucherRef'
+    _links:
+      $ref: ./_common.yml#/Links
 FulfillmentConstraint:
   type: object
   additionalProperties: false
@@ -289,10 +297,15 @@ FulfillmentDocument:
     Document created for fulfillment. Either downloadLink + downloadExpiry or content must
     be provided.
   required:
+  - id
   - medium
   - type
   - format
   properties:
+    id:
+      type: string
+      description: |
+        Technical reference. Required for referencing from fulfillment.fulfillmentDocumentRefs
     medium:
       $ref: '#/FulfillmentMediaType'
     type:
@@ -562,6 +575,12 @@ FulfillmentResponse:
         $ref: ./_common.yml#/Problem
     fulfillment:
       $ref: '#/Fulfillment'
+    fulfillmentDocuments:
+      description: |
+        Final document created for fulfillment.
+      type: array
+      items:
+        $ref: '#/FulfillmentDocument'
 FulfillmentsPatchRequest:
   type: object
   additionalProperties: false
@@ -687,3 +706,22 @@ SiSType:
   x-extensible-enum:
   - REGISTRY
   - PEER2PEER
+VoucherRef:
+  type: object
+  description: |
+    reference to a voucher issued during the sales process
+  additionalProperties: false
+  required:
+  - issuer
+  - code
+  properties:
+    issuer:
+      $ref: ./_common.yml#/CompanyRef
+    code:
+      description: |
+        voucher code provided by the issuer
+      type: string
+    fulfillmentRef:
+      description: |
+        reference to the fulfillment of the voucher.
+      $ref: '#/FulfillmentRefs'


### PR DESCRIPTION
## Summary

Port of commits `6b50b4db` + `2e87a181` (CGantert345, 2026-03-18) from the monolithic `v4.0/OSDM-online-api-v4.0.0-draft.yml` to the modular schema files on `dev-osdm-v4`.

### Design change: reference-based FulfillmentDocument

Previously `Fulfillment` embedded `FulfillmentDocument` objects inline. This caused duplication when multiple fulfillments shared documents. The new pattern:

- `Fulfillment.fulfillmentDocumentRefs` — array of string IDs (replacing `fulfillmentDocuments`)
- `FulfillmentCollectionResponse.fulfillmentDocuments` — actual document objects returned once at collection level
- `FulfillmentResponse.fulfillmentDocuments` — same for single-fulfillment responses
- `FulfillmentDocument.id` — new **required** field enabling the cross-reference

### Schema changes

| File | Change |
|---|---|
| `schemas/fulfillment.yml` | `FulfillmentDocument`: add required `id`; `Fulfillment`: `fulfillmentDocuments` → `fulfillmentDocumentRefs`; `FulfillmentCollectionResponse`: add `fulfillmentDocuments`, `issuedVoucherRefs`, `_links`; `FulfillmentResponse`: add `fulfillmentDocuments`; add `VoucherRef` schema |
| `schemas/_common.yml` | `VoucherInformation`: add description |
| `schemas/aftersales.yml` | `ConfirmedRefund`: `issuedFulfillmentIds` → `issuedFulfillmentRefs` (`FulfillmentRef`), `issuedVouchers` → `issuedVoucherRefs` (`VoucherRef`); `ExchangeOperation`: `issuedVouchers` → `issuedVoucherRefs` (`VoucherRef`) |

### Note on VoucherRef placement

`VoucherRef` is defined in `fulfillment.yml` (not `_common.yml`) because it carries a `fulfillmentRef` back-link to `FulfillmentRefs`. Placing it in `_common.yml` would create a circular file-level dependency since `fulfillment.yml` already imports `_common.yml`.

## Test plan

- [x] `redocly lint specification/OSDM-online-api.yml` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)