### PR TITLE
feat: add webhook specification for v4.0

### DIFF
--- a/specification/OSDM-online-webhook.yml
+++ b/specification/OSDM-online-webhook.yml
@@ -1,0 +1,280 @@
+openapi: 3.1.0
+servers:
+  - description: No server provided
+    url: /
+info:
+  title: UIC 90918-10 - OSDM webhooks
+  version: 4.0.0
+  description: |
+    Specifications for the OSDM API standard. The OSDM webhook specification allows an
+    allocator to inform a distributor about changes to a booking or a complaint.
+  contact:
+    name: OSDM Working Group
+    url: "https://osdm.io"
+    email: osdm@uic.org
+  license:
+    name: Apache 2.0
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+
+paths:
+  # OpenAPI documents all need a path element
+  /ping:
+    get:
+      summary: ping
+      operationId: ping
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+        "500":
+          description: internal server error
+        "501":
+          description: not implemented
+        "503":
+          description: service unavailable
+
+security:
+  - oAuth2ClientCredentials: []
+
+webhooks:
+  events:
+    post:
+      summary: Event occured
+      description: An event has occurred
+      operationId: postEvent
+      requestBody:
+        description: Information about the event
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/BookingEvent"
+                - $ref: "#/components/schemas/ComplaintEvent"
+                - $ref: "#/components/schemas/ReimbursementEvent"
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: bad input parameter
+        "401":
+          description: unauthorized
+        "403":
+          description: forbidden
+        "404":
+          description: no place information found
+        "500":
+          description: internal server error
+        "501":
+          description: not implemented
+        "503":
+          description: service unavailable
+
+components:
+  securitySchemes:
+    oAuth2ClientCredentials:
+      type: oauth2
+      description: |
+        See https://swagger.io/docs/specification/authentication/oauth2/
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://login.microsoftonline.com/tbd'
+          refreshUrl: 'https://refresh.url/tbd'
+          scopes: {}
+
+  schemas:
+    BookingEvent:
+      type: object
+      description: An event that has occurred on a booking.
+      required:
+        - objectType
+        - summary
+        - type
+        - revision
+        - bookingId
+        - resources
+      properties:
+        objectType:
+          type: string
+          enum:
+            - BookingEvent
+          default: BookingEvent
+        summary:
+          type: string
+          description: >-
+            Human readable description of what has changed on the booking. e.g.
+            "Train ICE 34 at 2021-12-22 13:30 has been cancelled".
+        type:
+          $ref: "#/components/schemas/BookingChangeType"
+        revision:
+          $ref: "#/components/schemas/Revision"
+        bookingId:
+          type: string
+          description: The ID of the booking that has changed.
+        affectedBookingPartIds:
+          description: list of ids of affected booking parts
+          type: array
+          items:
+            type: string
+        affectedFulfillmentIds:
+          description: list of ids of affected fulfillments
+          type: array
+          items:
+            type: string
+        resources:
+          description: >-
+            Resources to be called by receiver to update a booking.
+          type: array
+          items:
+            $ref: "#/components/schemas/Resource"
+
+    BookingChangeType:
+      type: string
+      description: >-
+        The type of change that has occurred on the booking.
+      enum:
+        - BOOKING_REAL_TIME_EVENT_OCCURRED
+        - BOOKING_REACCOMMODATED
+        - BOOKING_TRIP_CHANGED
+        - BOOKING_TRIP_CONFIRMED
+        - BOOKING_ON_HOLD
+        - DOCUMENT_AVAILABLE
+        - FULFILLMENT_AVAILABLE
+        - FULFILLMENT_REFUNDED
+        - FULFILLMENT_EXCHANGED
+        - FULFILLMENT_CANCELLED
+        - FULFILLMENT_RELEASED
+        - FULFILLMENT_CONTROLLED
+        - ACCOMMODATION_RELEASED
+        - PURCHASER_CHANGED
+        - PASSENGER_CHANGED
+        - REFUND_INITIATED
+        - EXCHANGE_INITIATED
+        - RELEASE_INITIATED
+        - CANCEL_INITIATED
+        - ON_HOLD_INITIATED
+        - AFTERSALES_OVERRIDEN
+        - CONTINUOUS_SERVICE_UPDATE
+        - CONTINUOUS_SERVICE_USAGE_BLOCKED
+        - CONTINUOUS_SERVICE_USAGE_UNBLOCKED
+        - CONTINUOUS_SERVICE_USAGE_STARTED
+        - CONTINUOUS_SERVICE_USAGE_ENDED
+        - CONTINUOUS_SERVICE_USAGE_UPDATE
+        - POST_PAYMENT_PRICING_UPDATE
+        - PRE_PAYMENT_PRICING_UPDATE
+      example: FULFILLMENT_REFUNDED
+
+    ComplaintEvent:
+      type: object
+      description: >-
+        An event that has occurred on a complaint.
+      required:
+        - objectType
+        - summary
+        - type
+        - revision
+        - complaintId
+        - resources
+      properties:
+        objectType:
+          type: string
+          enum:
+            - ComplaintEvent
+          default: ComplaintEvent
+        summary:
+          type: string
+          description: >-
+            Human readable description of what has changed on the complaint.
+            E.g. "Complaint 123456 has been settled".
+        type:
+          $ref: "#/components/schemas/BackOfficeChangeType"
+        revision:
+          $ref: "#/components/schemas/Revision"
+        complaintId:
+          type: string
+          description: The ID of the complaint.
+        resources:
+          description: >-
+            Resources to be called by receiver to update a complaint.
+          type: array
+          items:
+            $ref: "#/components/schemas/Resource"
+
+    ReimbursementEvent:
+      type: object
+      description: >-
+        An event that has occurred on a reimbursement.
+      required:
+        - objectType
+        - summary
+        - type
+        - revision
+        - reimbursementId
+        - resources
+      properties:
+        objectType:
+          type: string
+          enum:
+            - ReimbursementEvent
+          default: ReimbursementEvent
+        summary:
+          type: string
+          description: >-
+            Human readable description of what has changed on the reimbursement.
+            E.g. "Reimbursement 456-xyz has been settled".
+        type:
+          $ref: "#/components/schemas/BackOfficeChangeType"
+        revision:
+          $ref: "#/components/schemas/Revision"
+        reimbursementId:
+          type: string
+          description: The ID of the reimbursement.
+        resources:
+          description: >-
+            Resources to be called by receiver to update a reimbursement.
+          type: array
+          items:
+            $ref: "#/components/schemas/Resource"
+
+    BackOfficeChangeType:
+      type: string
+      description: The type of change that has occurred.
+      enum:
+        - INITIATED
+        - EVALUATING
+        - DECIDED
+        - SETTLED
+        - INFORMATION_MISSING
+      default: INITIATED
+
+    Revision:
+      type: object
+      description: The revision of the event.
+      required:
+        - name
+        - timestamp
+      properties:
+        name:
+          type: string
+          example: "1"
+        timestamp:
+          type: string
+          format: date-time
+
+    Resource:
+      type: object
+      description: >-
+        The resource to be called by receiver to update a booking, a complaint
+        or a reimbursement.
+      required:
+        - href
+      properties:
+        title:
+          type: string
+          description: >-
+            Intended for labelling the link with a human-readable identifier (as
+            defined by [RFC5988]).
+        href:
+          type: string
+          format: url
+          example: "https://db.de/osdm/bookings/2345/fulfillments/ASBV"


### PR DESCRIPTION
## Summary

Port of commit `52db5c81` (CGantert345 / Andreas Schlapbach, 2026-03-31) to `dev-osdm-v4`, adding the webhook specification as `specification/OSDM-online-webhook.yml` following the branch-based versioning convention.

The webhook spec allows an **allocator** to push event notifications to a **distributor** when resources change, avoiding the need for constant polling.

### Event types

| Schema | Discriminator value | Trigger |
|---|---|---|
| `BookingEvent` | `BookingEvent` | Any booking lifecycle change (see `BookingChangeType`) |
| `ComplaintEvent` | `ComplaintEvent` | Complaint state changes (see `BackOfficeChangeType`) |
| `ReimbursementEvent` | `ReimbursementEvent` | Reimbursement state changes (see `BackOfficeChangeType`) |

All events share: `objectType` (discriminator), `summary`, `revision`, `resources` (HATEOAS links for the receiver to refresh state).

`BookingChangeType` covers 28 values including fulfillment lifecycle (`FULFILLMENT_AVAILABLE`, `FULFILLMENT_REFUNDED`, …), trip changes (`BOOKING_TRIP_CHANGED`, `BOOKING_REACCOMMODATED`), after-sales initiations, and continuous service events.

### Fixes vs original draft

- `version`: `3.8.0` → `4.0.0`
- Typo: `"fulillments"` → `"fulfillments"` in `affectedFulfillmentIds` description
- Typo: `CONTINUOUS_SERVICE_USAGE_EDED` → `CONTINUOUS_SERVICE_USAGE_ENDED`
- `BackOfficeChangeType.default`: was incorrectly an array `[INITIATED]` → scalar `INITIATED`
- `Revision.name` example: bare integer `1` → quoted string `"1"`

## Test plan

- [x] `redocly lint specification/OSDM-online-webhook.yml` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)