### PR TITLE
Mark voucher amounts in PaymentMethod as readOnly

### DIFF
--- a/specification/schemas/_common.yml
+++ b/specification/schemas/_common.yml
@@ -980,7 +980,7 @@ PaymentMethod:
   type: object
   additionalProperties: false
   description: |
-    Method of payment used by the customer to the distributor. On input of voucher the remaining sum attribute and the applied voucher amount are not present.
+    Method of payment used by the customer to the distributor.
   required:
   - type
   properties:
@@ -989,9 +989,17 @@ PaymentMethod:
     voucherInformation:
       $ref: '#/VoucherInformation'
     remainingVoucherAmount:
-      $ref: '#/Price'
+      description: |
+        Remaining amount on the voucher after payment.
+      readOnly: true
+      allOf:
+      - $ref: '#/Price'
     appliedVoucherAmount:
-      $ref: '#/Price'
+      description: |
+        Voucher amount applied to the payment.
+      readOnly: true
+      allOf:
+      - $ref: '#/Price'
     transactionId:
       type: string
       nullable: true


### PR DESCRIPTION
Marking the `appliedVoucherAmount` and `remaningVoucherAmount` as `readOnly` allows to share the same `PaymentMethod` schema for both request and response, while omitting those amounts in the request