### PR TITLE
fix(#1475): add AncillarySubType and depreciate category in AncillaryOfferPart

### DIFF
--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -306,12 +306,19 @@ AncillaryOfferPart:
         items:
           $ref: '#/OfferPartReference'
       category:
+        deprecated: true
         description: |
           Categorization of the ancillary such as 'Meal' or 'Gift'.
+          Deprecated in favor to category2
         type: string
         nullable: true
+      category2:
+        $ref: '#/AncillaryCategory'
       type:
+        deprecated: true
         $ref: '#/AncillaryType'
+      subType:
+        $ref: '#/AncillarySubType'
       reservations:
         type: array
         items:
@@ -353,9 +360,11 @@ AncillarySelection:
       minItems: 1
       nullable: false
 AncillaryType:
+  deprecated: true
   description: |
     Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
     Listed values here are examples.
+    Deprecated in favor to AncillaryCategory
   type: string
   x-extensible-enum:
   - PAYMENT_VOUCHER
@@ -369,6 +378,67 @@ AncillaryType:
   - DRINKS_ON_BOARD
   - WIFI
   - PARKING
+AncillaryCategory:
+  description: |
+    Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
+    Listed values here are examples.
+  type: string
+  x-extensible-enum:
+    - PAYMENT_VOUCHER
+    - PRODUCT_ACCESS
+    - MERCHANDISE_PRODUCT
+    - LUGGAGE
+    - LUGGAGE_TRANSFER
+    - ON_BOARD_SERVICE
+    - STATION_SERVICE
+    - FOOD_ON_BOARD
+    - DRINKS_ON_BOARD
+    - WIFI
+    - PARKING
+    - ENTERTAINMENT
+    - PETS
+    - ASSISTANT
+AncillarySubType:
+  deprecated: true
+  description: |
+    Values from the [Ancillary SubType Code List](https://osdm.io/spec/catalog-of-code-lists/#ancillary-sub-types-)
+    Listed values here are examples.
+  type: string
+  x-extensible-enum:
+    - EXTRA_LARGE_SEAT
+    - SINGLE_SEAT
+    - UNCHECKED_PET
+    - CHECKED_PET
+    - ASSISTANCE_ANIMAL
+    - BREAKFAST
+    - LUNCH
+    - DINNER
+    - SNACK
+    - DRINKS_NO_ALCOHOL
+    - DRINKS_ALCOHOL
+    - FOOD_VOUCHER
+    - BIKE_NORMAL
+    - BIKE_FOLDABLE
+    - EBIKE_NO_CHARGE
+    - EBIKE_WITH_CHARGE
+    - SCOOTER
+    - BAG_SMALL
+    - BAG_LARGE
+    - CAR_SEAT
+    - BABY_COT
+    - PRAM_FOLDABLE
+    - WALKER
+    - WHEELCHAIR_FOLDED
+    - SPORTS_EQUIPMENT
+    - TRANSFER_NEXT_SERVICE
+    - HOME_DELIVERY
+    - CAR
+    - MOTORBIKE
+    - SPECIAL_VEHICLE
+    - TRAILER
+    - WIFI_STANDARD
+    - ESCORT_PMR
+    - ESCORT_MINOR
 CombinationTag:
   type: object
   additionalProperties: false

--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -309,7 +309,7 @@ AncillaryOfferPart:
         deprecated: true
         description: |
           Categorization of the ancillary such as 'Meal' or 'Gift'.
-          Deprecated in favor to category2
+          Deprecated; use category2 instead
         type: string
         nullable: true
       category2:
@@ -364,7 +364,7 @@ AncillaryType:
   description: |
     Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
     Listed values here are examples.
-    Deprecated in favor to AncillaryCategory
+    Deprecated; use AncillaryCategory instead
   type: string
   x-extensible-enum:
   - PAYMENT_VOUCHER

--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -376,7 +376,6 @@ AncillaryType:
   - WIFI
   - PARKING
 AncillarySubType:
-  deprecated: true
   description: |
     Values from the [Ancillary SubType Code List](https://osdm.io/spec/catalog-of-code-lists/#ancillary-sub-types-)
     Listed values here are examples.

--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -360,7 +360,7 @@ AncillarySelection:
       nullable: false
 AncillaryType:
   description: |
-    Values from the [Ancillary Type Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
+    Values from the [Ancillary Type Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryType)
     Listed values here are examples.
   type: string
   x-extensible-enum:

--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -273,6 +273,8 @@ Ancillary:
           $ref: ./booking.yml#/BookingPartReference
       type:
         $ref: '#/AncillaryType'
+      subType:
+        $ref: '#/AncillarySubType'
 AncillaryGroup:
   type: object
   additionalProperties: false
@@ -309,13 +311,10 @@ AncillaryOfferPart:
         deprecated: true
         description: |
           Categorization of the ancillary such as 'Meal' or 'Gift'.
-          Deprecated; use category2 instead
+          Deprecated; use subtype instead
         type: string
         nullable: true
-      category2:
-        $ref: '#/AncillaryCategory'
       type:
-        deprecated: true
         $ref: '#/AncillaryType'
       subType:
         $ref: '#/AncillarySubType'
@@ -360,11 +359,9 @@ AncillarySelection:
       minItems: 1
       nullable: false
 AncillaryType:
-  deprecated: true
   description: |
-    Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
+    Values from the [Ancillary Type Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
     Listed values here are examples.
-    Deprecated; use AncillaryCategory instead
   type: string
   x-extensible-enum:
   - PAYMENT_VOUCHER
@@ -378,26 +375,6 @@ AncillaryType:
   - DRINKS_ON_BOARD
   - WIFI
   - PARKING
-AncillaryCategory:
-  description: |
-    Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
-    Listed values here are examples.
-  type: string
-  x-extensible-enum:
-    - PAYMENT_VOUCHER
-    - PRODUCT_ACCESS
-    - MERCHANDISE_PRODUCT
-    - LUGGAGE
-    - LUGGAGE_TRANSFER
-    - ON_BOARD_SERVICE
-    - STATION_SERVICE
-    - FOOD_ON_BOARD
-    - DRINKS_ON_BOARD
-    - WIFI
-    - PARKING
-    - ENTERTAINMENT
-    - PETS
-    - ASSISTANT
 AncillarySubType:
   deprecated: true
   description: |


### PR DESCRIPTION
Fixes https://github.com/UnionInternationalCheminsdeFer/OSDM/issues/1475

This pr add a new property "subType" to `AncillaryOfferPart`. This property reflect the value of the [Ancillary SubType Code List](https://osdm.io/spec/catalog-of-code-lists/#ancillary-sub-types-). The property `category` is deprecied.

The PR is retrocompatible with previous versions of OSDM. 

To improve the consistency between the openapi spec and the code lists, the code list `AncillaryCategory` may be renamed to `AncillaryType`. 