### PR TITLE
Add missing comma and indentation

### DIFF
--- a/specification/v3.7/ERA_Technical Document_TAP_B_13-offline-model-v3.7.0.json
+++ b/specification/v3.7/ERA_Technical Document_TAP_B_13-offline-model-v3.7.0.json
@@ -2630,10 +2630,10 @@
 		        "UPGRADE_POINT2POINT",        
 		        "RESERVATION",      
 		        "ANCILLARY_SERVICE",   
-                        "ANCILLARY_ITEM", 
-                        "REDUCTION_CARD"
-                        ]
-                 }
+				"ANCILLARY_ITEM", 
+				"REDUCTION_CARD"
+			  ]
+        },
 		"CarrierGroup": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
The OSDM offline schema of the v3.7 branch is missing a comma.