### PR TITLE
fix(#1475): remove category in AncillaryOfferPart, replaced by AncillarySubType

### DIFF
--- a/specification/schemas/offer.yml
+++ b/specification/schemas/offer.yml
@@ -272,14 +272,10 @@ Ancillary:
         type: array
         items:
           $ref: ./booking.yml#/BookingPartReference
-      category:
-        description: |
-          Categorization of the ancillary such as 'Meal' or 'Gift'.
-        type:
-        - string
-        - 'null'
       type:
         $ref: '#/AncillaryType'
+      subType:
+        $ref: '#/AncillarySubType'
 AncillaryGroup:
   type: object
   additionalProperties: false
@@ -327,12 +323,6 @@ AncillaryOfferPart:
         type: array
         items:
           $ref: '#/OfferPartReference'
-      category:
-        description: |
-          Categorization of the ancillary such as 'Meal' or 'Gift'.
-        type:
-        - string
-        - 'null'
       type:
         $ref: '#/AncillaryType'
       subType:
@@ -382,7 +372,7 @@ AncillarySubType:
   - MUSICAL_INSTRUMENT
 AncillaryType:
   description: |
-    Values from the [Ancillary Category Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryCategory)
+    Values from the [Ancillary Type Code List](https://osdm.io/spec/catalog-of-code-lists/#AncillaryType)
     Listed values here are examples.
   type: string
   x-extensible-enum:
@@ -397,6 +387,46 @@ AncillaryType:
   - DRINKS_ON_BOARD
   - WIFI
   - PARKING
+AncillarySubType:
+  description: |
+    Values from the [Ancillary SubType Code List](https://osdm.io/spec/catalog-of-code-lists/#ancillary-sub-types-)
+    Listed values here are examples.
+  type: string
+  x-extensible-enum:
+    - EXTRA_LARGE_SEAT
+    - SINGLE_SEAT
+    - UNCHECKED_PET
+    - CHECKED_PET
+    - ASSISTANCE_ANIMAL
+    - BREAKFAST
+    - LUNCH
+    - DINNER
+    - SNACK
+    - DRINKS_NO_ALCOHOL
+    - DRINKS_ALCOHOL
+    - FOOD_VOUCHER
+    - BIKE_NORMAL
+    - BIKE_FOLDABLE
+    - EBIKE_NO_CHARGE
+    - EBIKE_WITH_CHARGE
+    - SCOOTER
+    - BAG_SMALL
+    - BAG_LARGE
+    - CAR_SEAT
+    - BABY_COT
+    - PRAM_FOLDABLE
+    - WALKER
+    - WHEELCHAIR_FOLDED
+    - SPORTS_EQUIPMENT
+    - TRANSFER_NEXT_SERVICE
+    - HOME_DELIVERY
+    - CAR
+    - MOTORBIKE
+    - SPECIAL_VEHICLE
+    - TRAILER
+    - WIFI_STANDARD
+    - ESCORT_PMR
+    - ESCORT_MINOR
 CombinationTag:
   type: object
   additionalProperties: false


### PR DESCRIPTION
This PR port the fix of #1475 (PR #1534) to v4.

The PR is NOT retrocompatible with previous versions of OSDM, because "category" is removed from Ancillary OfferPart.